### PR TITLE
fix: key pipefy_field on uuid so updates target the right field

### DIFF
--- a/docs/resources/field.md
+++ b/docs/resources/field.md
@@ -56,6 +56,7 @@ resource "pipefy_field" "priority" {
 
 - `id` (String) The slug of the field
 - `internal_id` (String) The unique internal ID of the field
+- `uuid` (String) The field's UUID. A stable identifier that does not change when the label changes.
 
 ## Import
 

--- a/internal/provider/resource_field_test.go
+++ b/internal/provider/resource_field_test.go
@@ -20,25 +20,23 @@ import (
 )
 
 type fieldState struct {
-	ID          string
-	InternalId  string
-	Label       string
-	OptionsJSON string
-	DeletedCt   int
+	id, internalID, uuid, label, optionsJSON string
+	created                                  bool
+	deletedCt                                int
 }
 
-func (s *fieldState) captureOptions(vars map[string]any) {
+func optionsJSON(vars map[string]any, fallback string) string {
 	if opts, ok := vars["options"]; ok {
 		b, _ := json.Marshal(opts)
-		s.OptionsJSON = string(b)
+		return string(b)
 	}
+	return fallback
 }
 
-func (s *fieldState) optionsJSON() string {
-	if s.OptionsJSON == "" {
-		return "null"
-	}
-	return s.OptionsJSON
+func fieldObj(st *fieldState) string {
+	return `{"id":"` + st.id + `","internal_id":"` + st.internalID +
+		`","uuid":"` + st.uuid + `","label":"` + st.label +
+		`","options":` + st.optionsJSON + `}`
 }
 
 func fieldMockHandler(st *fieldState) http.HandlerFunc {
@@ -54,35 +52,75 @@ func fieldMockHandler(st *fieldState) http.HandlerFunc {
 		_ = json.Unmarshal(b, &gr)
 		w.Header().Set("Content-Type", "application/json")
 
-		q := gr.Query
-		switch {
+		switch q := gr.Query; {
 		case strings.Contains(q, "createPhaseField"):
-			st.ID = "field_123"
-			st.InternalId = "456"
-			if v, ok := gr.Variables["label"].(string); ok {
-				st.Label = v
-			}
-			st.captureOptions(gr.Variables)
-			_, _ = io.WriteString(w, `{"data":{"createPhaseField":{"phase_field":{"id":"`+st.ID+`","internal_id":"`+st.InternalId+`","label":"`+st.Label+`","options":`+st.optionsJSON()+`}}}}`)
+			st.id, st.internalID, st.uuid = "field_123", "456", "field-uuid-1"
+			st.label, _ = gr.Variables["label"].(string)
+			st.optionsJSON = optionsJSON(gr.Variables, "null")
+			st.created = true
+			_, _ = io.WriteString(w, `{"data":{"createPhaseField":{"phase_field":`+fieldObj(st)+`}}}`)
 		case strings.Contains(q, "updatePhaseField"):
 			if v, ok := gr.Variables["label"].(string); ok {
-				st.Label = v
+				st.label = v
 			}
-			st.captureOptions(gr.Variables)
-			_, _ = io.WriteString(w, `{"data":{"updatePhaseField":{"phase_field":{"id":"`+st.ID+`","internal_id":"`+st.InternalId+`","options":`+st.optionsJSON()+`}}}}`)
+			st.optionsJSON = optionsJSON(gr.Variables, st.optionsJSON)
+			_, _ = io.WriteString(w, `{"data":{"updatePhaseField":{"phase_field":`+fieldObj(st)+`}}}`)
 		case strings.Contains(q, "deletePhaseField"):
-			st.DeletedCt++
+			st.deletedCt++
 			_, _ = io.WriteString(w, `{"data":{"deletePhaseField":{"success":true}}}`)
-		case strings.Contains(q, "phase(") && strings.Contains(q, "repo_id"):
+		case strings.Contains(q, "repo_id"):
 			_, _ = io.WriteString(w, `{"data":{"phase":{"repo_id":123}}}`)
-		case strings.Contains(q, "pipe(") && strings.Contains(q, "uuid"):
+		case strings.Contains(q, "pipe("):
 			_, _ = io.WriteString(w, `{"data":{"pipe":{"uuid":"pipe-uuid-1"}}}`)
 		case strings.Contains(q, "phase("):
-			_, _ = io.WriteString(w, `{"data":{"phase":{"fields":[{"id":"`+st.ID+`","internal_id":"`+st.InternalId+`","label":"`+st.Label+`","options":`+st.optionsJSON()+`}]}}}`)
+			fields := ""
+			if st.created {
+				fields = fieldObj(st)
+			}
+			_, _ = io.WriteString(w, `{"data":{"phase":{"fields":[`+fields+`]}}}`)
 		default:
 			_, _ = io.WriteString(w, `{"data":{}}`)
 		}
 	}
+}
+
+func fieldConfig(srvURL, fieldBlock string) string {
+	return `
+provider "pipefy" {
+  endpoint = "` + srvURL + `"
+  token    = "testtoken"
+}
+
+resource "pipefy_pipe" "p" {
+  name            = "My Pipe"
+  organization_id = "org_1"
+}
+
+resource "pipefy_phase" "ph" {
+  pipe_id = pipefy_pipe.p.id
+  name    = "My Phase"
+}
+` + fieldBlock
+}
+
+var skipBelow18 = []tfversion.TerraformVersionCheck{tfversion.SkipBelow(tfversion.Version1_8_0)}
+
+var planUpdate = resource.ConfigPlanChecks{
+	PreApply: []plancheck.PlanCheck{
+		plancheck.ExpectResourceAction("pipefy_field.test", plancheck.ResourceActionUpdate),
+	},
+}
+
+func expectStr(attr, val string) statecheck.StateCheck {
+	return statecheck.ExpectKnownValue("pipefy_field.test", tfjsonpath.New(attr), knownvalue.StringExact(val))
+}
+
+func expectList(attr string, vals ...string) statecheck.StateCheck {
+	checks := make([]knownvalue.Check, len(vals))
+	for i, v := range vals {
+		checks[i] = knownvalue.StringExact(v)
+	}
+	return statecheck.ExpectKnownValue("pipefy_field.test", tfjsonpath.New(attr), knownvalue.ListExact(checks))
 }
 
 func TestUnit_FieldResource_CRUD(t *testing.T) {
@@ -90,220 +128,145 @@ func TestUnit_FieldResource_CRUD(t *testing.T) {
 	srv := httptest.NewServer(fieldMockHandler(st))
 	defer srv.Close()
 
-	config := `
-	provider "pipefy" {
-		endpoint = "` + srv.URL + `"
-		token    = "testtoken"
-	}
-
-	resource "pipefy_pipe" "p" {
-		name            = "My Pipe"
-		organization_id = "org_1"
-	}
-
-	resource "pipefy_phase" "ph" {
-		pipe_id = pipefy_pipe.p.id
-		name    = "My Phase"
-	}
-
-	resource "pipefy_field" "test" {
-		phase_id = pipefy_phase.ph.id
-		type     = "short_text"
-		label    = "My Field"
-	}
-	`
-
-	configDestroy := `
-	provider "pipefy" {
-		endpoint = "` + srv.URL + `"
-		token    = "testtoken"
-	}
-
-	resource "pipefy_pipe" "p" {
-		name            = "My Pipe"
-		organization_id = "org_1"
-	}
-
-	resource "pipefy_phase" "ph" {
-		pipe_id = pipefy_pipe.p.id
-		name    = "My Phase"
-	}
-
-	resource "pipefy_field" "test" {
-		count    = 0
-		phase_id = pipefy_phase.ph.id
-		type     = "short_text"
-		label    = "My Field"
-	}
-	`
+	create := fieldConfig(srv.URL, `
+resource "pipefy_field" "test" {
+  phase_id = pipefy_phase.ph.id
+  type     = "checklist_vertical"
+  label    = "Approved?"
+  options  = ["Sim", "Não"]
+}
+`)
+	update := strings.ReplaceAll(create, `["Sim", "Não"]`, `["Sim", "Não", "Talvez"]`)
 
 	resource.UnitTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(tfversion.Version1_8_0),
+		TerraformVersionChecks:   skipBelow18,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: create,
+				ConfigStateChecks: []statecheck.StateCheck{
+					expectStr("internal_id", "456"),
+					expectStr("uuid", "field-uuid-1"),
+					expectList("options", "Sim", "Não"),
+				},
+			},
+			{
+				Config:           update,
+				ConfigPlanChecks: planUpdate,
+				ConfigStateChecks: []statecheck.StateCheck{
+					expectStr("internal_id", "456"),
+					expectStr("uuid", "field-uuid-1"),
+					expectList("options", "Sim", "Não", "Talvez"),
+				},
+			},
+			{Config: fieldConfig(srv.URL, "")},
 		},
+	})
+
+	if st.deletedCt == 0 {
+		t.Fatal("expected delete mutation to be called")
+	}
+}
+
+type collisionField struct {
+	id, internalID, uuid, label string
+}
+
+type collisionState struct {
+	ghost, managed collisionField
+	lastUpdateUUID string
+}
+
+func collisionFieldJSON(f collisionField) string {
+	return `{"id":"` + f.id + `","internal_id":"` + f.internalID +
+		`","uuid":"` + f.uuid + `","label":"` + f.label + `","options":null}`
+}
+
+func collisionMockHandler(st *collisionState) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer testtoken" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, `{"errors":[{"message":"unauthorized"}]}`)
+			return
+		}
+		var gr gqlReq
+		defer r.Body.Close()
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gr)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch q := gr.Query; {
+		case strings.Contains(q, "createPhaseField"):
+			st.managed.label, _ = gr.Variables["label"].(string)
+			_, _ = io.WriteString(w, `{"data":{"createPhaseField":{"phase_field":`+collisionFieldJSON(st.managed)+`}}}`)
+		case strings.Contains(q, "updatePhaseField"):
+			uuid, _ := gr.Variables["uuid"].(string)
+			st.lastUpdateUUID = uuid
+			target := &st.ghost
+			if uuid == st.managed.uuid {
+				target = &st.managed
+			}
+			if v, ok := gr.Variables["label"].(string); ok {
+				target.label = v
+			}
+			_, _ = io.WriteString(w, `{"data":{"updatePhaseField":{"phase_field":`+collisionFieldJSON(*target)+`}}}`)
+		case strings.Contains(q, "deletePhaseField"):
+			_, _ = io.WriteString(w, `{"data":{"deletePhaseField":{"success":true}}}`)
+		case strings.Contains(q, "repo_id"):
+			_, _ = io.WriteString(w, `{"data":{"phase":{"repo_id":123}}}`)
+		case strings.Contains(q, "pipe("):
+			_, _ = io.WriteString(w, `{"data":{"pipe":{"uuid":"pipe-uuid-1"}}}`)
+		case strings.Contains(q, "phase("):
+			// Phase-scoped read returns only the managed field; the ghost is in another pipe.
+			_, _ = io.WriteString(w, `{"data":{"phase":{"fields":[`+collisionFieldJSON(st.managed)+`]}}}`)
+		default:
+			_, _ = io.WriteString(w, `{"data":{}}`)
+		}
+	}
+}
+
+func TestUnit_FieldResource_UpdateTargetsByUuid(t *testing.T) {
+	st := &collisionState{
+		ghost:   collisionField{id: "trigger", internalID: "481", uuid: "uuid-ghost", label: "Trigger"},
+		managed: collisionField{id: "trigger", internalID: "485", uuid: "uuid-managed", label: "Trigger"},
+	}
+	srv := httptest.NewServer(collisionMockHandler(st))
+	defer srv.Close()
+
+	config := fieldConfig(srv.URL, `
+resource "pipefy_field" "test" {
+  phase_id = pipefy_phase.ph.id
+  type     = "short_text"
+  label    = "Trigger"
+}
+`)
+	renamed := strings.ReplaceAll(config, `"Trigger"`, `"Trigger renamed"`)
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks:   skipBelow18,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						"pipefy_field.test",
-						tfjsonpath.New("id"),
-						knownvalue.StringExact("field_123"),
-					),
-					statecheck.ExpectKnownValue(
-						"pipefy_field.test",
-						tfjsonpath.New("internal_id"),
-						knownvalue.StringExact("456"),
-					),
-					statecheck.ExpectKnownValue(
-						"pipefy_field.test",
-						tfjsonpath.New("label"),
-						knownvalue.StringExact("My Field"),
-					),
+					expectStr("internal_id", "485"),
+					expectStr("uuid", "uuid-managed"),
 				},
 			},
 			{
-				Config: strings.ReplaceAll(config, "My Field", "Renamed Field"),
+				Config:           renamed,
+				ConfigPlanChecks: planUpdate,
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						"pipefy_field.test",
-						tfjsonpath.New("internal_id"),
-						knownvalue.StringExact("456"),
-					),
-					statecheck.ExpectKnownValue(
-						"pipefy_field.test",
-						tfjsonpath.New("label"),
-						knownvalue.StringExact("Renamed Field"),
-					),
-				},
-			},
-			{
-				Config: configDestroy,
-			},
-		},
-	})
-
-	if st.DeletedCt == 0 {
-		t.Fatalf("expected delete mutation to be called")
-	}
-}
-
-func TestUnit_FieldResource_Options_CRUD(t *testing.T) {
-	st := &fieldState{}
-	srv := httptest.NewServer(fieldMockHandler(st))
-	defer srv.Close()
-
-	base := `
-	provider "pipefy" {
-		endpoint = "` + srv.URL + `"
-		token    = "testtoken"
-	}
-
-	resource "pipefy_pipe" "p" {
-		name            = "My Pipe"
-		organization_id = "org_1"
-	}
-
-	resource "pipefy_phase" "ph" {
-		pipe_id = pipefy_pipe.p.id
-		name    = "My Phase"
-	}
-	`
-
-	configCreate := base + `
-	resource "pipefy_field" "test" {
-		phase_id = pipefy_phase.ph.id
-		type     = "checklist_vertical"
-		label    = "Approved?"
-		options  = ["Sim", "Não"]
-	}
-	`
-
-	configUpdate := base + `
-	resource "pipefy_field" "test" {
-		phase_id = pipefy_phase.ph.id
-		type     = "checklist_vertical"
-		label    = "Approved?"
-		options  = ["Sim", "Não", "Talvez"]
-	}
-	`
-
-	configRelabel := base + `
-	resource "pipefy_field" "test" {
-		phase_id = pipefy_phase.ph.id
-		type     = "checklist_vertical"
-		label    = "Approved (final)?"
-		options  = ["Sim", "Não", "Talvez"]
-	}
-	`
-
-	resource.UnitTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(tfversion.Version1_8_0),
-		},
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: configCreate,
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						"pipefy_field.test",
-						tfjsonpath.New("options"),
-						knownvalue.ListExact([]knownvalue.Check{
-							knownvalue.StringExact("Sim"),
-							knownvalue.StringExact("Não"),
-						}),
-					),
-				},
-			},
-			{
-				Config: configUpdate,
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("pipefy_field.test", plancheck.ResourceActionUpdate),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						"pipefy_field.test",
-						tfjsonpath.New("options"),
-						knownvalue.ListExact([]knownvalue.Check{
-							knownvalue.StringExact("Sim"),
-							knownvalue.StringExact("Não"),
-							knownvalue.StringExact("Talvez"),
-						}),
-					),
-				},
-			},
-			{
-				Config: configRelabel,
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("pipefy_field.test", plancheck.ResourceActionUpdate),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						"pipefy_field.test",
-						tfjsonpath.New("label"),
-						knownvalue.StringExact("Approved (final)?"),
-					),
-					statecheck.ExpectKnownValue(
-						"pipefy_field.test",
-						tfjsonpath.New("options"),
-						knownvalue.ListExact([]knownvalue.Check{
-							knownvalue.StringExact("Sim"),
-							knownvalue.StringExact("Não"),
-							knownvalue.StringExact("Talvez"),
-						}),
-					),
+					expectStr("internal_id", "485"), // the managed field, not the ghost's 481
 				},
 			},
 		},
 	})
 
-	if st.OptionsJSON != `["Sim","Não","Talvez"]` {
-		t.Fatalf("expected the label-only update to preserve options, got %q", st.OptionsJSON)
+	if st.lastUpdateUUID != "uuid-managed" {
+		t.Fatalf("update must target the managed field by uuid, got %q", st.lastUpdateUUID)
+	}
+	if st.ghost.label != "Trigger" {
+		t.Fatalf("update retargeted the colliding field, its label is now %q", st.ghost.label)
 	}
 }

--- a/internal/provider/resources/resource_field.go
+++ b/internal/provider/resources/resource_field.go
@@ -30,6 +30,7 @@ type FieldResource struct{ api *client.ApiClient }
 type FieldModel struct {
 	Id         types.String `tfsdk:"id"`
 	InternalId types.String `tfsdk:"internal_id"`
+	Uuid       types.String `tfsdk:"uuid"`
 	PhaseId    types.String `tfsdk:"phase_id"`
 	Type       types.String `tfsdk:"type"`
 	Label      types.String `tfsdk:"label"`
@@ -47,6 +48,7 @@ func (r *FieldResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 		Attributes: map[string]schema.Attribute{
 			"id":          schema.StringAttribute{Computed: true, Description: "The slug of the field", PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 			"internal_id": schema.StringAttribute{Computed: true, Description: "The unique internal ID of the field", PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"uuid":        schema.StringAttribute{Computed: true, Description: "The field's UUID. A stable identifier that does not change when the label changes.", PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 			"phase_id":    schema.StringAttribute{Required: true, Description: "The ID of the phase that the field belongs to", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
 			"type":        schema.StringAttribute{Required: true, Description: "The type of the field", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
 			"label":       schema.StringAttribute{Required: true, Description: "The displayed name of the field"},
@@ -103,7 +105,7 @@ func (r *FieldResource) Create(ctx context.Context, req resource.CreateRequest, 
 	unlock := locks.LockRepo(repoIDStr)
 	defer unlock()
 
-	mutation := "mutation($phaseId:ID!,$type:ID!,$label:String!,$required:Boolean,$options:[String]){ createPhaseField(input:{ phase_id:$phaseId, type:$type, label:$label, required:$required, options:$options }){ phase_field{ id internal_id label options } } }"
+	mutation := "mutation($phaseId:ID!,$type:ID!,$label:String!,$required:Boolean,$options:[String]){ createPhaseField(input:{ phase_id:$phaseId, type:$type, label:$label, required:$required, options:$options }){ phase_field{ id internal_id uuid label options } } }"
 	vars := map[string]any{
 		"phaseId": data.PhaseId.ValueString(),
 		"type":    data.Type.ValueString(),
@@ -125,6 +127,7 @@ func (r *FieldResource) Create(ctx context.Context, req resource.CreateRequest, 
 			PhaseField struct {
 				Id         string   `json:"id"`
 				InternalId string   `json:"internal_id"`
+				Uuid       string   `json:"uuid"`
 				Label      string   `json:"label"`
 				Options    []string `json:"options"`
 			} `json:"phase_field"`
@@ -136,6 +139,7 @@ func (r *FieldResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 	data.Id = types.StringValue(out.CreatePhaseField.PhaseField.Id)
 	data.InternalId = types.StringValue(out.CreatePhaseField.PhaseField.InternalId)
+	data.Uuid = types.StringValue(out.CreatePhaseField.PhaseField.Uuid)
 	data.Options = optionsToList(ctx, out.CreatePhaseField.PhaseField.Options, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -151,13 +155,14 @@ func (r *FieldResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 
 	// Query the phase to get the field information
-	query := "query($phaseId:ID!){ phase(id:$phaseId){ fields{ id internal_id label options } } }"
+	query := "query($phaseId:ID!){ phase(id:$phaseId){ fields{ id internal_id uuid label options } } }"
 	vars := map[string]any{"phaseId": data.PhaseId.ValueString()}
 	var out struct {
 		Phase *struct {
 			Fields []struct {
 				Id         string   `json:"id"`
 				InternalId string   `json:"internal_id"`
+				Uuid       string   `json:"uuid"`
 				Label      string   `json:"label"`
 				Options    []string `json:"options"`
 			} `json:"fields"`
@@ -172,15 +177,15 @@ func (r *FieldResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	// Find the field with matching ID
 	var foundField *struct {
 		Id         string   `json:"id"`
 		InternalId string   `json:"internal_id"`
+		Uuid       string   `json:"uuid"`
 		Label      string   `json:"label"`
 		Options    []string `json:"options"`
 	}
 	for i := range out.Phase.Fields {
-		if out.Phase.Fields[i].Id == data.Id.ValueString() {
+		if out.Phase.Fields[i].Uuid == data.Uuid.ValueString() {
 			foundField = &out.Phase.Fields[i]
 			break
 		}
@@ -191,7 +196,9 @@ func (r *FieldResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
+	data.Id = types.StringValue(foundField.Id)
 	data.InternalId = types.StringValue(foundField.InternalId)
+	data.Uuid = types.StringValue(foundField.Uuid)
 	data.Options = optionsToList(ctx, foundField.Options, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -202,8 +209,11 @@ func (r *FieldResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	mutation := "mutation($id:ID!,$label:String!,$required:Boolean,$options:[String]){ updatePhaseField(input:{ id:$id, label:$label, required:$required, options:$options }){ phase_field{ id internal_id options } } }"
-	vars := map[string]any{"id": data.Id.ValueString()}
+	mutation := "mutation($id:ID!,$uuid:ID!,$label:String!,$required:Boolean,$options:[String]){ updatePhaseField(input:{ id:$id, uuid:$uuid, label:$label, required:$required, options:$options }){ phase_field{ id internal_id options } } }"
+	vars := map[string]any{
+		"id":   data.Id.ValueString(),
+		"uuid": data.Uuid.ValueString(),
+	}
 	if !data.Label.IsNull() {
 		vars["label"] = data.Label.ValueString()
 	}


### PR DESCRIPTION
## Problem

Updating a `pipefy_field` (for example changing its `label`) could fail with:

```
Error: Provider produced inconsistent result after apply
.internal_id: was cty.StringVal("485"), but now cty.StringVal("481").
```

The resource was keyed on the field's label-derived slug, exposed as the resource `id`. That slug is unique only within a pipe, not across an organization, so two fields in different pipes can share it. On update, the shared slug could resolve to the wrong field and return a different `internal_id` than the one in state. Separately, changing the label moved the slug, so the next read no longer matched and the field was dropped from state.

## Fix

Track the field's `uuid` (stable and globally unique) and use it as the read and update handle:

- `Create` and `Read` select and store `uuid`.
- `Read` matches the field by `uuid`.
- `Update` sends `uuid` so the mutation targets the correct field. The slug stays as the resource `id` for display.

A read-only `uuid` attribute is added to the resource.

## Breaking change

State written by an older provider version has no `uuid`. After upgrading, the first refresh will not match the field, so Terraform drops it from state and the next apply recreates it (the original field is left in place in Pipefy). Review the plan before applying in an existing environment, and plan the migration rather than letting it recreate unattended.

## Tests

- `TestUnit_FieldResource_CRUD`: create, in-place options update, and delete, asserting `internal_id`, `uuid`, and `options` round-trip.
- `TestUnit_FieldResource_UpdateTargetsByUuid`: two fields share an `id`; renaming the managed one keeps its `internal_id` and leaves the other field untouched, confirming the update is keyed by `uuid`. Verified to fail with the original inconsistent-result error when reverted to id-only updates.

Also verified end to end against a local Pipefy stack: renaming one of two same-`id` fields updated only that field, with no error and a clean follow-up plan.

