### PR TITLE
fix: serialize phase creation per pipe

### DIFF
--- a/internal/provider/resources/resource_phase.go
+++ b/internal/provider/resources/resource_phase.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/pipefy/terraform-provider-pipefy/internal/provider/client"
+	"github.com/pipefy/terraform-provider-pipefy/internal/provider/locks"
 )
 
 var _ resource.Resource = &PhaseResource{}
@@ -62,6 +63,10 @@ func (r *PhaseResource) Create(ctx context.Context, req resource.CreateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Pipefy rejects concurrent phase creates for the same pipe; serialize per pipe.
+	unlock := locks.LockRepo(data.PipeId.ValueString())
+	defer unlock()
 
 	mutation := "mutation($pipeId:ID!,$name:String!){ createPhase(input:{ pipe_id: $pipeId, name: $name }){ phase{ id name } } }"
 	vars := map[string]any{"pipeId": data.PipeId.ValueString(), "name": data.Name.ValueString()}


### PR DESCRIPTION
## Problem

The Pipefy API rejects concurrent `createPhase` calls for the same pipe. When a configuration defines several `pipefy_phase` resources in one pipe, Terraform creates them in parallel at default parallelism, so some creates are rejected. The apply ends in a broken state: rejected phases are missing from state, and resources that depend on them (fields, automations) never run. The only workaround today is `terraform apply -parallelism=1`, which slows every apply and is easy to forget.

Closes #33.

## Fix

Acquire a per-pipe lock in `PhaseResource.Create` before the `createPhase` mutation, keyed on `pipe_id`, and release it with `defer`. This reuses the existing `locks.LockRepo` helper that `pipefy_field` already uses for the same constraint. Different pipes still create in parallel; only creates targeting the same pipe are serialized. `Update`, `Delete`, and `Read` are unchanged, since the constraint is specific to concurrent creates.

## Verification

- `make build`, `go vet ./...`, `gofmt`, `go vet`, and `make test` pass.
- End to end against a real stack with a config of 10 `pipefy_phase` resources in one pipe at default parallelism:
  - Before the change: 4 of 10 phases created, 6 failed with `graphql error: Something went wrong`.
  - After the change: all 10 created, and a scaled run of 25 phases on one pipe also created cleanly. Staggered completion times confirm the creates are serialized per pipe while Terraform still dispatches them in parallel.