### PR TITLE
Expand pipefy_phase schema: done, description, ordering, SLA, draft intake

### DIFF
--- a/docs/resources/phase.md
+++ b/docs/resources/phase.md
@@ -23,7 +23,6 @@ resource "pipefy_phase" "example" {
   name        = "Backlog"
   description = "Work waiting to be triaged"
   index       = 1
-  color       = "blue"
 }
 
 resource "pipefy_phase" "done" {
@@ -46,7 +45,6 @@ resource "pipefy_phase" "done" {
 ### Optional
 
 - `can_receive_card_directly_from_draft` (Boolean) Whether cards can be created directly in this phase
-- `color` (String) Color of the phase. One of: blue, cyan, gray, green, indigo, lime, orange, pink, purple, red, sky, yellow.
 - `description` (String) Description of the phase
 - `done` (Boolean) Whether the phase is a final phase
 - `index` (Number) Position of the phase on the board. The API only accepts index at creation, so changing a configured index forces replacement of the phase (cards in the phase are lost). Reordering phases outside Terraform also changes index, so a configured index can trigger replacement after such drift.

--- a/docs/resources/phase.md
+++ b/docs/resources/phase.md
@@ -19,8 +19,19 @@ resource "pipefy_pipe" "example" {
 }
 
 resource "pipefy_phase" "example" {
-  pipe_id = pipefy_pipe.example.id
-  name    = "Backlog"
+  pipe_id     = pipefy_pipe.example.id
+  name        = "Backlog"
+  description = "Work waiting to be triaged"
+  index       = 1
+  color       = "blue"
+}
+
+resource "pipefy_phase" "done" {
+  pipe_id                              = pipefy_pipe.example.id
+  name                                 = "Done"
+  done                                 = true
+  lateness_time                        = 86400
+  can_receive_card_directly_from_draft = false
 }
 ```
 
@@ -31,6 +42,15 @@ resource "pipefy_phase" "example" {
 
 - `name` (String) Name of the phase
 - `pipe_id` (String) The ID of the pipe that the phase belongs to
+
+### Optional
+
+- `can_receive_card_directly_from_draft` (Boolean) Whether cards can be created directly in this phase
+- `color` (String) Color of the phase. One of: blue, cyan, gray, green, indigo, lime, orange, pink, purple, red, sky, yellow.
+- `description` (String) Description of the phase
+- `done` (Boolean) Whether the phase is a final phase
+- `index` (Number) Position of the phase on the board. The API only accepts index at creation, so changing a configured index forces replacement of the phase (cards in the phase are lost). Reordering phases outside Terraform also changes index, so a configured index can trigger replacement after such drift.
+- `lateness_time` (Number) SLA of the phase, in seconds
 
 ### Read-Only
 

--- a/examples/resources/pipefy_phase/resource.tf
+++ b/examples/resources/pipefy_phase/resource.tf
@@ -4,6 +4,17 @@ resource "pipefy_pipe" "example" {
 }
 
 resource "pipefy_phase" "example" {
-  pipe_id = pipefy_pipe.example.id
-  name    = "Backlog"
+  pipe_id     = pipefy_pipe.example.id
+  name        = "Backlog"
+  description = "Work waiting to be triaged"
+  index       = 1
+  color       = "blue"
+}
+
+resource "pipefy_phase" "done" {
+  pipe_id                              = pipefy_pipe.example.id
+  name                                 = "Done"
+  done                                 = true
+  lateness_time                        = 86400
+  can_receive_card_directly_from_draft = false
 }

--- a/examples/resources/pipefy_phase/resource.tf
+++ b/examples/resources/pipefy_phase/resource.tf
@@ -8,7 +8,6 @@ resource "pipefy_phase" "example" {
   name        = "Backlog"
   description = "Work waiting to be triaged"
   index       = 1
-  color       = "blue"
 }
 
 resource "pipefy_phase" "done" {

--- a/internal/provider/resource_phase_test.go
+++ b/internal/provider/resource_phase_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -26,13 +25,10 @@ type phaseState struct {
 	Done            bool
 	Description     *string
 	Index           *float64
-	Color           *string
 	LatenessTime    *int64
 	CanReceiveDraft *bool
 	Deleted         bool
-	FailUpdate      bool
 	DeletedCt       int
-	CreateSawColor  bool
 	UpdateSawIndex  bool
 }
 
@@ -43,7 +39,6 @@ func (st *phaseState) toJSON() string {
 		"done":                                 st.Done,
 		"description":                          st.Description,
 		"index":                                st.Index,
-		"color":                                st.Color,
 		"lateness_time":                        st.LatenessTime,
 		"can_receive_card_directly_from_draft": st.CanReceiveDraft,
 		"repo_id":                              301,
@@ -86,11 +81,7 @@ func newPhaseServer(st *phaseState) *httptest.Server {
 		switch q := gr.Query; {
 		case strings.Contains(q, "createPhase"):
 			st.ID = "phase_123"
-			st.Color = nil
 			st.Deleted = false
-			if _, ok := gr.Variables["color"]; ok {
-				st.CreateSawColor = true
-			}
 			if v, ok := gr.Variables["index"].(float64); ok {
 				st.Index = &v
 			} else {
@@ -101,15 +92,8 @@ func newPhaseServer(st *phaseState) *httptest.Server {
 			merge()
 			_, _ = io.WriteString(w, `{"data":{"createPhase":{"phase":`+st.toJSON()+`}}}`)
 		case strings.Contains(q, "updatePhase"):
-			if st.FailUpdate {
-				_, _ = io.WriteString(w, `{"errors":[{"message":"color update failed"}]}`)
-				return
-			}
 			if _, ok := gr.Variables["index"]; ok {
 				st.UpdateSawIndex = true
-			}
-			if v, ok := gr.Variables["color"].(string); ok {
-				st.Color = &v
 			}
 			merge()
 			_, _ = io.WriteString(w, `{"data":{"updatePhase":{"phase":`+st.toJSON()+`}}}`)
@@ -163,7 +147,6 @@ func TestUnit_PhaseResource_CRUD(t *testing.T) {
 			done                                 = true
 			description                          = "First description"
 			index                                = 1
-			color                                = "blue"
 			lateness_time                        = 3600
 			can_receive_card_directly_from_draft = true
 	`
@@ -172,7 +155,6 @@ func TestUnit_PhaseResource_CRUD(t *testing.T) {
 			done                                 = false
 			description                          = "Second description"
 			index                                = 1
-			color                                = "red"
 			lateness_time                        = 7200
 			can_receive_card_directly_from_draft = false
 	`
@@ -202,7 +184,6 @@ func TestUnit_PhaseResource_CRUD(t *testing.T) {
 					phaseValue("name", knownvalue.StringExact("My Phase")),
 					phaseValue("done", knownvalue.Bool(false)),
 					phaseValue("description", knownvalue.Null()),
-					phaseValue("color", knownvalue.Null()),
 					phaseValue("index", knownvalue.Float64Exact(5)),
 				},
 			},
@@ -214,15 +195,13 @@ func TestUnit_PhaseResource_CRUD(t *testing.T) {
 				},
 			},
 			{
-				// index is create-only, so setting it forces replacement; color
-				// must reach the API through the follow-up update after create.
+				// index is create-only, so setting it forces replacement.
 				Config:           config(fullAttrsInitial),
 				ConfigPlanChecks: expectAction(plancheck.ResourceActionReplace),
 				ConfigStateChecks: []statecheck.StateCheck{
 					phaseValue("done", knownvalue.Bool(true)),
 					phaseValue("description", knownvalue.StringExact("First description")),
 					phaseValue("index", knownvalue.Float64Exact(1)),
-					phaseValue("color", knownvalue.StringExact("blue")),
 					phaseValue("lateness_time", knownvalue.Int64Exact(3600)),
 					phaseValue("can_receive_card_directly_from_draft", knownvalue.Bool(true)),
 				},
@@ -233,7 +212,6 @@ func TestUnit_PhaseResource_CRUD(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					phaseValue("done", knownvalue.Bool(false)),
 					phaseValue("description", knownvalue.StringExact("Second description")),
-					phaseValue("color", knownvalue.StringExact("red")),
 					phaseValue("lateness_time", knownvalue.Int64Exact(7200)),
 					phaseValue("can_receive_card_directly_from_draft", knownvalue.Bool(false)),
 				},
@@ -264,9 +242,6 @@ func TestUnit_PhaseResource_CRUD(t *testing.T) {
 		},
 	})
 
-	if st.CreateSawColor {
-		t.Errorf("createPhase must not receive a color variable; the API only accepts it on updatePhase")
-	}
 	if st.UpdateSawIndex {
 		t.Errorf("updatePhase must not receive an index variable; the API only accepts it on createPhase")
 	}
@@ -275,48 +250,5 @@ func TestUnit_PhaseResource_CRUD(t *testing.T) {
 	}
 	if st.DeletedCt < 2 {
 		t.Fatalf("expected deletes from the index replacement and the final destroy, got %d", st.DeletedCt)
-	}
-}
-
-// A failed follow-up color update must keep the created phase in state so
-// terraform taints and replaces it instead of leaking it.
-func TestUnit_PhaseResource_CreateColorFailureKeepsPhaseInState(t *testing.T) {
-	st := &phaseState{FailUpdate: true}
-	srv := newPhaseServer(st)
-	defer srv.Close()
-
-	config := `
-	provider "pipefy" {
-		endpoint = "` + srv.URL + `"
-		token    = "testtoken"
-	}
-
-	resource "pipefy_pipe" "p" {
-		name            = "My Pipe"
-		organization_id = "org_1"
-	}
-
-	resource "pipefy_phase" "test" {
-		pipe_id = pipefy_pipe.p.id
-		name    = "My Phase"
-		color   = "blue"
-	}
-	`
-
-	resource.UnitTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(tfversion.Version1_8_0),
-		},
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      config,
-				ExpectError: regexp.MustCompile(`setting its color failed`),
-			},
-		},
-	})
-
-	if st.DeletedCt != 1 {
-		t.Fatalf("expected the half-created phase to be destroyed during cleanup, got %d deletes", st.DeletedCt)
 	}
 }

--- a/internal/provider/resource_phase_test.go
+++ b/internal/provider/resource_phase_test.go
@@ -8,25 +8,51 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 type phaseState struct {
-	ID        string
-	Name      string
-	DeletedCt int
+	ID              string
+	Name            string
+	Done            bool
+	Description     *string
+	Index           *float64
+	Color           *string
+	LatenessTime    *int64
+	CanReceiveDraft *bool
+	Deleted         bool
+	FailUpdate      bool
+	DeletedCt       int
+	CreateSawColor  bool
+	UpdateSawIndex  bool
 }
 
-func TestUnit_PhaseResource_CRUD(t *testing.T) {
-	st := &phaseState{}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func (st *phaseState) toJSON() string {
+	b, _ := json.Marshal(map[string]any{
+		"id":                                   st.ID,
+		"name":                                 st.Name,
+		"done":                                 st.Done,
+		"description":                          st.Description,
+		"index":                                st.Index,
+		"color":                                st.Color,
+		"lateness_time":                        st.LatenessTime,
+		"can_receive_card_directly_from_draft": st.CanReceiveDraft,
+		"repo_id":                              301,
+	})
+	return string(b)
+}
+
+func newPhaseServer(st *phaseState) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer testtoken" {
 			w.WriteHeader(http.StatusUnauthorized)
 			_, _ = io.WriteString(w, `{"errors":[{"message":"unauthorized"}]}`)
@@ -38,28 +64,225 @@ func TestUnit_PhaseResource_CRUD(t *testing.T) {
 		_ = json.Unmarshal(b, &gr)
 		w.Header().Set("Content-Type", "application/json")
 
-		q := gr.Query
-		switch {
+		merge := func() {
+			if v, ok := gr.Variables["name"].(string); ok {
+				st.Name = v
+			}
+			if v, ok := gr.Variables["done"].(bool); ok {
+				st.Done = v
+			}
+			if v, ok := gr.Variables["description"].(string); ok {
+				st.Description = &v
+			}
+			if v, ok := gr.Variables["latenessTime"].(float64); ok {
+				lt := int64(v)
+				st.LatenessTime = &lt
+			}
+			if v, ok := gr.Variables["canReceiveCardDirectlyFromDraft"].(bool); ok {
+				st.CanReceiveDraft = &v
+			}
+		}
+
+		switch q := gr.Query; {
 		case strings.Contains(q, "createPhase"):
 			st.ID = "phase_123"
-			if v, ok := gr.Variables["name"].(string); ok {
-				st.Name = v
+			st.Color = nil
+			st.Deleted = false
+			if _, ok := gr.Variables["color"]; ok {
+				st.CreateSawColor = true
 			}
-			_, _ = io.WriteString(w, `{"data":{"createPhase":{"phase":{"id":"`+st.ID+`","name":"`+st.Name+`"}}}}`)
+			if v, ok := gr.Variables["index"].(float64); ok {
+				st.Index = &v
+			} else {
+				// The real API always assigns a position.
+				serverAssigned := 5.0
+				st.Index = &serverAssigned
+			}
+			merge()
+			_, _ = io.WriteString(w, `{"data":{"createPhase":{"phase":`+st.toJSON()+`}}}`)
 		case strings.Contains(q, "updatePhase"):
-			if v, ok := gr.Variables["name"].(string); ok {
-				st.Name = v
+			if st.FailUpdate {
+				_, _ = io.WriteString(w, `{"errors":[{"message":"color update failed"}]}`)
+				return
 			}
-			_, _ = io.WriteString(w, `{"data":{"updatePhase":{"phase":{"id":"`+st.ID+`"}}}}`)
+			if _, ok := gr.Variables["index"]; ok {
+				st.UpdateSawIndex = true
+			}
+			if v, ok := gr.Variables["color"].(string); ok {
+				st.Color = &v
+			}
+			merge()
+			_, _ = io.WriteString(w, `{"data":{"updatePhase":{"phase":`+st.toJSON()+`}}}`)
 		case strings.Contains(q, "deletePhase"):
 			st.DeletedCt++
 			_, _ = io.WriteString(w, `{"data":{"deletePhase":{"success":true}}}`)
 		case strings.Contains(q, "phase("):
-			_, _ = io.WriteString(w, `{"data":{"phase":{"id":"`+st.ID+`","name":"`+st.Name+`"}}}`)
+			if st.Deleted {
+				_, _ = io.WriteString(w, `{"data":{"phase":null}}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"data":{"phase":`+st.toJSON()+`}}`)
+		case strings.Contains(q, "createPipe"):
+			_, _ = io.WriteString(w, `{"data":{"createPipe":{"pipe":{"id":"301","name":"My Pipe"}}}}`)
+		case strings.Contains(q, "deletePipe"):
+			_, _ = io.WriteString(w, `{"data":{"deletePipe":{"success":true}}}`)
+		case strings.Contains(q, "pipe("):
+			_, _ = io.WriteString(w, `{"data":{"pipe":{"id":"301","name":"My Pipe","startFormPhaseId":"","phases":[]}}}`)
 		default:
 			_, _ = io.WriteString(w, `{"data":{}}`)
 		}
 	}))
+}
+
+func TestUnit_PhaseResource_CRUD(t *testing.T) {
+	st := &phaseState{}
+	srv := newPhaseServer(st)
+	defer srv.Close()
+
+	config := func(attrs string) string {
+		return `
+		provider "pipefy" {
+			endpoint = "` + srv.URL + `"
+			token    = "testtoken"
+		}
+
+		resource "pipefy_pipe" "p" {
+			name            = "My Pipe"
+			organization_id = "org_1"
+		}
+
+		resource "pipefy_phase" "test" {
+			pipe_id = pipefy_pipe.p.id
+` + attrs + `
+		}
+		`
+	}
+
+	fullAttrsInitial := `
+			name                                 = "Renamed Phase"
+			done                                 = true
+			description                          = "First description"
+			index                                = 1
+			color                                = "blue"
+			lateness_time                        = 3600
+			can_receive_card_directly_from_draft = true
+	`
+	fullAttrsUpdated := `
+			name                                 = "Renamed Phase"
+			done                                 = false
+			description                          = "Second description"
+			index                                = 1
+			color                                = "red"
+			lateness_time                        = 7200
+			can_receive_card_directly_from_draft = false
+	`
+
+	phaseValue := func(attr string, v knownvalue.Check) statecheck.StateCheck {
+		return statecheck.ExpectKnownValue("pipefy_phase.test", tfjsonpath.New(attr), v)
+	}
+	expectAction := func(action plancheck.ResourceActionType) resource.ConfigPlanChecks {
+		return resource.ConfigPlanChecks{
+			PreApply: []plancheck.PlanCheck{
+				plancheck.ExpectResourceAction("pipefy_phase.test", action),
+			},
+		}
+	}
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Minimal create: computed attributes resolve from API defaults.
+				Config: config(`name = "My Phase"`),
+				ConfigStateChecks: []statecheck.StateCheck{
+					phaseValue("id", knownvalue.StringExact("phase_123")),
+					phaseValue("name", knownvalue.StringExact("My Phase")),
+					phaseValue("done", knownvalue.Bool(false)),
+					phaseValue("description", knownvalue.Null()),
+					phaseValue("color", knownvalue.Null()),
+					phaseValue("index", knownvalue.Float64Exact(5)),
+				},
+			},
+			{
+				Config:           config(`name = "Renamed Phase"`),
+				ConfigPlanChecks: expectAction(plancheck.ResourceActionUpdate),
+				ConfigStateChecks: []statecheck.StateCheck{
+					phaseValue("name", knownvalue.StringExact("Renamed Phase")),
+				},
+			},
+			{
+				// index is create-only, so setting it forces replacement; color
+				// must reach the API through the follow-up update after create.
+				Config:           config(fullAttrsInitial),
+				ConfigPlanChecks: expectAction(plancheck.ResourceActionReplace),
+				ConfigStateChecks: []statecheck.StateCheck{
+					phaseValue("done", knownvalue.Bool(true)),
+					phaseValue("description", knownvalue.StringExact("First description")),
+					phaseValue("index", knownvalue.Float64Exact(1)),
+					phaseValue("color", knownvalue.StringExact("blue")),
+					phaseValue("lateness_time", knownvalue.Int64Exact(3600)),
+					phaseValue("can_receive_card_directly_from_draft", knownvalue.Bool(true)),
+				},
+			},
+			{
+				Config:           config(fullAttrsUpdated),
+				ConfigPlanChecks: expectAction(plancheck.ResourceActionUpdate),
+				ConfigStateChecks: []statecheck.StateCheck{
+					phaseValue("done", knownvalue.Bool(false)),
+					phaseValue("description", knownvalue.StringExact("Second description")),
+					phaseValue("color", knownvalue.StringExact("red")),
+					phaseValue("lateness_time", knownvalue.Int64Exact(7200)),
+					phaseValue("can_receive_card_directly_from_draft", knownvalue.Bool(false)),
+				},
+			},
+			{
+				// Read must catch server-side drift so the apply writes it back.
+				PreConfig: func() {
+					drifted := "drifted outside terraform"
+					st.Description = &drifted
+				},
+				Config:           config(fullAttrsUpdated),
+				ConfigPlanChecks: expectAction(plancheck.ResourceActionUpdate),
+				ConfigStateChecks: []statecheck.StateCheck{
+					phaseValue("description", knownvalue.StringExact("Second description")),
+				},
+			},
+			{
+				// A phase deleted outside terraform must be recreated.
+				PreConfig:        func() { st.Deleted = true },
+				Config:           config(fullAttrsUpdated),
+				ConfigPlanChecks: expectAction(plancheck.ResourceActionCreate),
+			},
+			{
+				ResourceName:      "pipefy_phase.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+
+	if st.CreateSawColor {
+		t.Errorf("createPhase must not receive a color variable; the API only accepts it on updatePhase")
+	}
+	if st.UpdateSawIndex {
+		t.Errorf("updatePhase must not receive an index variable; the API only accepts it on createPhase")
+	}
+	if st.Description == nil || *st.Description != "Second description" {
+		t.Errorf("drifted description was not written back to the API: got %v", st.Description)
+	}
+	if st.DeletedCt < 2 {
+		t.Fatalf("expected deletes from the index replacement and the final destroy, got %d", st.DeletedCt)
+	}
+}
+
+// A failed follow-up color update must keep the created phase in state so
+// terraform taints and replaces it instead of leaking it.
+func TestUnit_PhaseResource_CreateColorFailureKeepsPhaseInState(t *testing.T) {
+	st := &phaseState{FailUpdate: true}
+	srv := newPhaseServer(st)
 	defer srv.Close()
 
 	config := `
@@ -76,24 +299,7 @@ func TestUnit_PhaseResource_CRUD(t *testing.T) {
 	resource "pipefy_phase" "test" {
 		pipe_id = pipefy_pipe.p.id
 		name    = "My Phase"
-	}
-	`
-
-	configDestroy := `
-	provider "pipefy" {
-		endpoint = "` + srv.URL + `"
-		token    = "testtoken"
-	}
-
-	resource "pipefy_pipe" "p" {
-		name            = "My Pipe"
-		organization_id = "org_1"
-	}
-
-	resource "pipefy_phase" "test" {
-		count   = 0
-		pipe_id = pipefy_pipe.p.id
-		name    = "My Phase"
+		color   = "blue"
 	}
 	`
 
@@ -104,37 +310,13 @@ func TestUnit_PhaseResource_CRUD(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						"pipefy_phase.test",
-						tfjsonpath.New("id"),
-						knownvalue.StringExact("phase_123"),
-					),
-					statecheck.ExpectKnownValue(
-						"pipefy_phase.test",
-						tfjsonpath.New("name"),
-						knownvalue.StringExact("My Phase"),
-					),
-				},
-			},
-			{
-				Config: strings.ReplaceAll(config, "My Phase", "Renamed Phase"),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						"pipefy_phase.test",
-						tfjsonpath.New("name"),
-						knownvalue.StringExact("Renamed Phase"),
-					),
-				},
-			},
-			{
-				Config: configDestroy,
+				Config:      config,
+				ExpectError: regexp.MustCompile(`setting its color failed`),
 			},
 		},
 	})
 
-	if st.DeletedCt == 0 {
-		t.Fatalf("expected delete mutation to be called")
+	if st.DeletedCt != 1 {
+		t.Fatalf("expected the half-created phase to be destroyed during cleanup, got %d deletes", st.DeletedCt)
 	}
 }

--- a/internal/provider/resources/resource_phase.go
+++ b/internal/provider/resources/resource_phase.go
@@ -6,10 +6,13 @@ package resources
 import (
 	"context"
 	"fmt"
+	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -25,9 +28,81 @@ func NewPhaseResource() resource.Resource { return &PhaseResource{} }
 type PhaseResource struct{ api *client.ApiClient }
 
 type PhaseModel struct {
-	Id     types.String `tfsdk:"id"`
-	PipeId types.String `tfsdk:"pipe_id"`
-	Name   types.String `tfsdk:"name"`
+	Id                              types.String  `tfsdk:"id"`
+	PipeId                          types.String  `tfsdk:"pipe_id"`
+	Name                            types.String  `tfsdk:"name"`
+	Done                            types.Bool    `tfsdk:"done"`
+	Description                     types.String  `tfsdk:"description"`
+	Index                           types.Float64 `tfsdk:"index"`
+	Color                           types.String  `tfsdk:"color"`
+	LatenessTime                    types.Int64   `tfsdk:"lateness_time"`
+	CanReceiveCardDirectlyFromDraft types.Bool    `tfsdk:"can_receive_card_directly_from_draft"`
+}
+
+const phaseSelection = "id name done description index color lateness_time can_receive_card_directly_from_draft repo_id"
+
+type phasePayload struct {
+	Id                              string   `json:"id"`
+	Name                            string   `json:"name"`
+	Done                            bool     `json:"done"`
+	Description                     *string  `json:"description"`
+	Index                           *float64 `json:"index"`
+	Color                           *string  `json:"color"`
+	LatenessTime                    *int64   `json:"lateness_time"`
+	CanReceiveCardDirectlyFromDraft *bool    `json:"can_receive_card_directly_from_draft"`
+	RepoId                          int64    `json:"repo_id"`
+}
+
+func (m *PhaseModel) setFromApi(p phasePayload) {
+	m.Id = types.StringValue(p.Id)
+	m.Name = types.StringValue(p.Name)
+	if p.RepoId != 0 {
+		m.PipeId = types.StringValue(strconv.FormatInt(p.RepoId, 10))
+	}
+	m.Done = types.BoolValue(p.Done)
+	m.Description = types.StringPointerValue(p.Description)
+	m.Index = types.Float64PointerValue(p.Index)
+	m.Color = types.StringPointerValue(p.Color)
+	m.LatenessTime = types.Int64PointerValue(p.LatenessTime)
+	m.CanReceiveCardDirectlyFromDraft = types.BoolPointerValue(p.CanReceiveCardDirectlyFromDraft)
+}
+
+func (m *PhaseModel) fillUnknowns(p phasePayload) {
+	if m.Done.IsUnknown() {
+		m.Done = types.BoolValue(p.Done)
+	}
+	if m.Description.IsUnknown() {
+		m.Description = types.StringPointerValue(p.Description)
+	}
+	if m.Index.IsUnknown() {
+		m.Index = types.Float64PointerValue(p.Index)
+	}
+	if m.Color.IsUnknown() {
+		m.Color = types.StringPointerValue(p.Color)
+	}
+	if m.LatenessTime.IsUnknown() {
+		m.LatenessTime = types.Int64PointerValue(p.LatenessTime)
+	}
+	if m.CanReceiveCardDirectlyFromDraft.IsUnknown() {
+		m.CanReceiveCardDirectlyFromDraft = types.BoolPointerValue(p.CanReceiveCardDirectlyFromDraft)
+	}
+}
+
+func hasValue(v attr.Value) bool { return !v.IsNull() && !v.IsUnknown() }
+
+func (m *PhaseModel) addSharedPhaseVars(vars map[string]any) {
+	if hasValue(m.Done) {
+		vars["done"] = m.Done.ValueBool()
+	}
+	if hasValue(m.Description) {
+		vars["description"] = m.Description.ValueString()
+	}
+	if hasValue(m.LatenessTime) {
+		vars["latenessTime"] = m.LatenessTime.ValueInt64()
+	}
+	if hasValue(m.CanReceiveCardDirectlyFromDraft) {
+		vars["canReceiveCardDirectlyFromDraft"] = m.CanReceiveCardDirectlyFromDraft.ValueBool()
+	}
 }
 
 func (r *PhaseResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -38,9 +113,20 @@ func (r *PhaseResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Phase resource",
 		Attributes: map[string]schema.Attribute{
-			"id":      schema.StringAttribute{Computed: true, Description: "The ID of the phase", PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
-			"pipe_id": schema.StringAttribute{Required: true, Description: "The ID of the pipe that the phase belongs to", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
-			"name":    schema.StringAttribute{Required: true, Description: "Name of the phase"},
+			"id":          schema.StringAttribute{Computed: true, Description: "The ID of the phase", PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"pipe_id":     schema.StringAttribute{Required: true, Description: "The ID of the pipe that the phase belongs to", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
+			"name":        schema.StringAttribute{Required: true, Description: "Name of the phase"},
+			"done":        schema.BoolAttribute{Optional: true, Computed: true, Description: "Whether the phase is a final phase"},
+			"description": schema.StringAttribute{Optional: true, Computed: true, Description: "Description of the phase"},
+			"index": schema.Float64Attribute{
+				Optional:      true,
+				Computed:      true,
+				Description:   "Position of the phase on the board. The API only accepts index at creation, so changing a configured index forces replacement of the phase (cards in the phase are lost). Reordering phases outside Terraform also changes index, so a configured index can trigger replacement after such drift.",
+				PlanModifiers: []planmodifier.Float64{float64planmodifier.RequiresReplaceIfConfigured()},
+			},
+			"color":                                schema.StringAttribute{Optional: true, Computed: true, Description: "Color of the phase. One of: blue, cyan, gray, green, indigo, lime, orange, pink, purple, red, sky, yellow."},
+			"lateness_time":                        schema.Int64Attribute{Optional: true, Computed: true, Description: "SLA of the phase, in seconds"},
+			"can_receive_card_directly_from_draft": schema.BoolAttribute{Optional: true, Computed: true, Description: "Whether cards can be created directly in this phase"},
 		},
 	}
 }
@@ -68,22 +154,48 @@ func (r *PhaseResource) Create(ctx context.Context, req resource.CreateRequest, 
 	unlock := locks.LockRepo(data.PipeId.ValueString())
 	defer unlock()
 
-	mutation := "mutation($pipeId:ID!,$name:String!){ createPhase(input:{ pipe_id: $pipeId, name: $name }){ phase{ id name } } }"
+	mutation := "mutation($pipeId:ID!,$name:String!,$done:Boolean,$description:String,$index:Float,$latenessTime:Int,$canReceiveCardDirectlyFromDraft:Boolean){ createPhase(input:{ pipe_id:$pipeId, name:$name, done:$done, description:$description, index:$index, lateness_time:$latenessTime, can_receive_card_directly_from_draft:$canReceiveCardDirectlyFromDraft }){ phase{ " + phaseSelection + " } } }"
 	vars := map[string]any{"pipeId": data.PipeId.ValueString(), "name": data.Name.ValueString()}
+	data.addSharedPhaseVars(vars)
+	if hasValue(data.Index) {
+		vars["index"] = data.Index.ValueFloat64()
+	}
 	var out struct {
 		CreatePhase struct {
-			Phase struct {
-				Id   string `json:"id"`
-				Name string `json:"name"`
-			} `json:"phase"`
+			Phase phasePayload `json:"phase"`
 		} `json:"createPhase"`
 	}
 	if err := r.api.DoGraphQL(ctx, mutation, vars, &out); err != nil {
 		resp.Diagnostics.AddError("create phase failed", err.Error())
 		return
 	}
-	data.Id = types.StringValue(out.CreatePhase.Phase.Id)
+	phase := out.CreatePhase.Phase
+
+	// createPhase does not accept color; apply it with a follow-up update.
+	// The other attributes are re-sent so the update cannot reset them.
+	var colorErr error
+	if hasValue(data.Color) {
+		updateVars := map[string]any{
+			"id":    phase.Id,
+			"name":  data.Name.ValueString(),
+			"color": data.Color.ValueString(),
+		}
+		data.addSharedPhaseVars(updateVars)
+		if updated, err := r.updatePhase(ctx, updateVars); err != nil {
+			colorErr = err
+		} else {
+			phase = updated
+		}
+	}
+
+	// State is saved even when the color update failed, so terraform
+	// taints the phase instead of leaking it outside of state.
+	data.Id = types.StringValue(phase.Id)
+	data.fillUnknowns(phase)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if colorErr != nil {
+		resp.Diagnostics.AddError("create phase failed", fmt.Sprintf("phase %s was created but setting its color failed: %s", phase.Id, colorErr.Error()))
+	}
 }
 
 func (r *PhaseResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -96,13 +208,10 @@ func (r *PhaseResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	query := "query($id:ID!){ phase(id:$id){ id name } }"
+	query := "query($id:ID!){ phase(id:$id){ " + phaseSelection + " } }"
 	vars := map[string]any{"id": data.Id.ValueString()}
 	var out struct {
-		Phase *struct {
-			Id   string `json:"id"`
-			Name string `json:"name"`
-		} `json:"phase"`
+		Phase *phasePayload `json:"phase"`
 	}
 	if err := r.api.DoGraphQL(ctx, query, vars, &out); err != nil {
 		resp.Diagnostics.AddError("read phase failed", err.Error())
@@ -112,6 +221,7 @@ func (r *PhaseResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		resp.State.RemoveResource(ctx)
 		return
 	}
+	data.setFromApi(*out.Phase)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -121,23 +231,31 @@ func (r *PhaseResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	mutation := "mutation($id:ID!,$name:String!){ updatePhase(input:{ id:$id, name:$name }){ phase{ id } } }"
-	vars := map[string]any{"id": data.Id.ValueString()}
-	if !data.Name.IsNull() {
-		vars["name"] = data.Name.ValueString()
+	vars := map[string]any{"id": data.Id.ValueString(), "name": data.Name.ValueString()}
+	data.addSharedPhaseVars(vars)
+	if hasValue(data.Color) {
+		vars["color"] = data.Color.ValueString()
 	}
-	var out struct {
-		UpdatePhase struct {
-			Phase struct {
-				Id string `json:"id"`
-			} `json:"phase"`
-		} `json:"updatePhase"`
-	}
-	if err := r.api.DoGraphQL(ctx, mutation, vars, &out); err != nil {
+	phase, err := r.updatePhase(ctx, vars)
+	if err != nil {
 		resp.Diagnostics.AddError("update phase failed", err.Error())
 		return
 	}
+	data.fillUnknowns(phase)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *PhaseResource) updatePhase(ctx context.Context, vars map[string]any) (phasePayload, error) {
+	mutation := "mutation($id:ID!,$name:String!,$done:Boolean,$description:String,$color:Colors,$latenessTime:Int,$canReceiveCardDirectlyFromDraft:Boolean){ updatePhase(input:{ id:$id, name:$name, done:$done, description:$description, color:$color, lateness_time:$latenessTime, can_receive_card_directly_from_draft:$canReceiveCardDirectlyFromDraft }){ phase{ " + phaseSelection + " } } }"
+	var out struct {
+		UpdatePhase struct {
+			Phase phasePayload `json:"phase"`
+		} `json:"updatePhase"`
+	}
+	if err := r.api.DoGraphQL(ctx, mutation, vars, &out); err != nil {
+		return phasePayload{}, err
+	}
+	return out.UpdatePhase.Phase, nil
 }
 
 func (r *PhaseResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/resources/resource_phase.go
+++ b/internal/provider/resources/resource_phase.go
@@ -34,12 +34,11 @@ type PhaseModel struct {
 	Done                            types.Bool    `tfsdk:"done"`
 	Description                     types.String  `tfsdk:"description"`
 	Index                           types.Float64 `tfsdk:"index"`
-	Color                           types.String  `tfsdk:"color"`
 	LatenessTime                    types.Int64   `tfsdk:"lateness_time"`
 	CanReceiveCardDirectlyFromDraft types.Bool    `tfsdk:"can_receive_card_directly_from_draft"`
 }
 
-const phaseSelection = "id name done description index color lateness_time can_receive_card_directly_from_draft repo_id"
+const phaseSelection = "id name done description index lateness_time can_receive_card_directly_from_draft repo_id"
 
 type phasePayload struct {
 	Id                              string   `json:"id"`
@@ -47,7 +46,6 @@ type phasePayload struct {
 	Done                            bool     `json:"done"`
 	Description                     *string  `json:"description"`
 	Index                           *float64 `json:"index"`
-	Color                           *string  `json:"color"`
 	LatenessTime                    *int64   `json:"lateness_time"`
 	CanReceiveCardDirectlyFromDraft *bool    `json:"can_receive_card_directly_from_draft"`
 	RepoId                          int64    `json:"repo_id"`
@@ -62,7 +60,6 @@ func (m *PhaseModel) setFromApi(p phasePayload) {
 	m.Done = types.BoolValue(p.Done)
 	m.Description = types.StringPointerValue(p.Description)
 	m.Index = types.Float64PointerValue(p.Index)
-	m.Color = types.StringPointerValue(p.Color)
 	m.LatenessTime = types.Int64PointerValue(p.LatenessTime)
 	m.CanReceiveCardDirectlyFromDraft = types.BoolPointerValue(p.CanReceiveCardDirectlyFromDraft)
 }
@@ -76,9 +73,6 @@ func (m *PhaseModel) fillUnknowns(p phasePayload) {
 	}
 	if m.Index.IsUnknown() {
 		m.Index = types.Float64PointerValue(p.Index)
-	}
-	if m.Color.IsUnknown() {
-		m.Color = types.StringPointerValue(p.Color)
 	}
 	if m.LatenessTime.IsUnknown() {
 		m.LatenessTime = types.Int64PointerValue(p.LatenessTime)
@@ -124,7 +118,8 @@ func (r *PhaseResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Description:   "Position of the phase on the board. The API only accepts index at creation, so changing a configured index forces replacement of the phase (cards in the phase are lost). Reordering phases outside Terraform also changes index, so a configured index can trigger replacement after such drift.",
 				PlanModifiers: []planmodifier.Float64{float64planmodifier.RequiresReplaceIfConfigured()},
 			},
-			"color":                                schema.StringAttribute{Optional: true, Computed: true, Description: "Color of the phase. One of: blue, cyan, gray, green, indigo, lime, orange, pink, purple, red, sky, yellow."},
+			// color is intentionally not managed: the Pipefy API rejects
+			// changing a phase color, so exposing it would only error.
 			"lateness_time":                        schema.Int64Attribute{Optional: true, Computed: true, Description: "SLA of the phase, in seconds"},
 			"can_receive_card_directly_from_draft": schema.BoolAttribute{Optional: true, Computed: true, Description: "Whether cards can be created directly in this phase"},
 		},
@@ -171,31 +166,9 @@ func (r *PhaseResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 	phase := out.CreatePhase.Phase
 
-	// createPhase does not accept color; apply it with a follow-up update.
-	// The other attributes are re-sent so the update cannot reset them.
-	var colorErr error
-	if hasValue(data.Color) {
-		updateVars := map[string]any{
-			"id":    phase.Id,
-			"name":  data.Name.ValueString(),
-			"color": data.Color.ValueString(),
-		}
-		data.addSharedPhaseVars(updateVars)
-		if updated, err := r.updatePhase(ctx, updateVars); err != nil {
-			colorErr = err
-		} else {
-			phase = updated
-		}
-	}
-
-	// State is saved even when the color update failed, so terraform
-	// taints the phase instead of leaking it outside of state.
 	data.Id = types.StringValue(phase.Id)
 	data.fillUnknowns(phase)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-	if colorErr != nil {
-		resp.Diagnostics.AddError("create phase failed", fmt.Sprintf("phase %s was created but setting its color failed: %s", phase.Id, colorErr.Error()))
-	}
 }
 
 func (r *PhaseResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -231,31 +204,20 @@ func (r *PhaseResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	mutation := "mutation($id:ID!,$name:String!,$done:Boolean,$description:String,$latenessTime:Int,$canReceiveCardDirectlyFromDraft:Boolean){ updatePhase(input:{ id:$id, name:$name, done:$done, description:$description, lateness_time:$latenessTime, can_receive_card_directly_from_draft:$canReceiveCardDirectlyFromDraft }){ phase{ " + phaseSelection + " } } }"
 	vars := map[string]any{"id": data.Id.ValueString(), "name": data.Name.ValueString()}
 	data.addSharedPhaseVars(vars)
-	if hasValue(data.Color) {
-		vars["color"] = data.Color.ValueString()
-	}
-	phase, err := r.updatePhase(ctx, vars)
-	if err != nil {
-		resp.Diagnostics.AddError("update phase failed", err.Error())
-		return
-	}
-	data.fillUnknowns(phase)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-}
-
-func (r *PhaseResource) updatePhase(ctx context.Context, vars map[string]any) (phasePayload, error) {
-	mutation := "mutation($id:ID!,$name:String!,$done:Boolean,$description:String,$color:Colors,$latenessTime:Int,$canReceiveCardDirectlyFromDraft:Boolean){ updatePhase(input:{ id:$id, name:$name, done:$done, description:$description, color:$color, lateness_time:$latenessTime, can_receive_card_directly_from_draft:$canReceiveCardDirectlyFromDraft }){ phase{ " + phaseSelection + " } } }"
 	var out struct {
 		UpdatePhase struct {
 			Phase phasePayload `json:"phase"`
 		} `json:"updatePhase"`
 	}
 	if err := r.api.DoGraphQL(ctx, mutation, vars, &out); err != nil {
-		return phasePayload{}, err
+		resp.Diagnostics.AddError("update phase failed", err.Error())
+		return
 	}
-	return out.UpdatePhase.Phase, nil
+	data.fillUnknowns(out.UpdatePhase.Phase)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *PhaseResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {


### PR DESCRIPTION
Closes #39.

Adds `done`, `description`, `index`, `lateness_time`, and `can_receive_card_directly_from_draft` to `pipefy_phase`. All five are Optional and Computed, so an unset attribute follows whatever the API assigns instead of showing a perpetual diff. `Read` now refreshes every attribute, which also fixes two prior gaps: `name` was never refreshed (so renames outside Terraform were invisible), and `pipe_id` was never populated on import.

## Attribute coverage

The attribute set comes from introspection of `CreatePhaseInput`, `UpdatePhaseInput`, and the `Phase` type:

| Attribute | createPhase | updatePhase | Readable on Phase |
| --- | --- | --- | --- |
| `done` | yes | yes | yes |
| `description` | yes | yes | yes |
| `index` | yes (Float) | no | yes |
| `lateness_time` | yes (Int) | yes | yes |
| `can_receive_card_directly_from_draft` | yes | yes | yes |

## Notes for review

**`index` is create-only and forces replacement.** `UpdatePhaseInput` has no `index` field and there is no phase-reorder mutation, so position can only be set at creation. The attribute uses `RequiresReplaceIfConfigured`, not plain `RequiresReplace`: a null computed `index` gets marked unknown whenever the plan carries any other change, and plain `RequiresReplace` would then destroy and recreate any phase with a null index on every unrelated edit. A side effect is that reordering phases on the board outside Terraform drifts `index`, which can trigger replacement (and card loss) on the next apply when `index` is configured. The attribute description states this.

**Import resolves the parent pipe via `repo_id`.** `Phase.repo_id` is the pipe ID, so `Read` sets `pipe_id` from it. Without this, `terraform import` left `pipe_id` null and the first plan would force replacement of the just-imported phase, since `pipe_id` carries `RequiresReplace`.

**`color` is intentionally not managed.** The Pipefy API rejects changing a phase color, so a managed `color` attribute would only produce errors. It is left out, with a note in the schema.

**`only_admin_can_move_to_previous` was dropped from the issue's list.** The argument is marked `ARGUMENT IS DEPRECATED!` in both `createPhase` and `updatePhase`, and the `Phase` type exposes no matching field. Without a readable counterpart, drift could never be detected, so managing it would be a write-only attribute that violates the issue's own requirement that Read refresh everything.

## Testing

`TestUnit_PhaseResource_CRUD` is a single CRUD test against a stateful mock server that also answers pipe queries. It covers minimal create with server-assigned defaults, in-place updates, the replacement triggered by configuring `index`, server-side drift correction, recreate after an external delete, and `ImportStateVerify`. A wire-level assertion confirms `updatePhase` never receives an `index` variable.

The five attributes were also verified end-to-end against a live Pipefy stack: create, no-drift re-plan, in-place update, and import all clean.

`make test`, `make build`, `go vet`, and `gofmt -s` are clean. `make lint` was not run because `golangci-lint` is not installed locally; CI should cover it. Docs were regenerated with `make generate`.
