### PR TITLE
Add User-Agent header, name GraphQL operations, refactor field/label reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ main.go                    # Provider entrypoint
 ## Conventions
 
 - Terraform attribute names are snake_case; resource type names are prefixed `pipefy_`.
+- Name every GraphQL operation with a descriptive PascalCase name and a `_tf` suffix: `Get*` for queries, `Create*` / `Update*` / `Delete*` for mutations, naming the entity and the action (`query GetPipe_tf($id:ID!){ ... }`, `mutation CreateLabel_tf(...)`). The `_tf` marker identifies the request as provider traffic in server-side traces and logs. Each request carries one operation, so the name in the document is enough; no separate `operationName` field is needed.
 - Register every resource and data source in `provider.go` via the `Resources()` and `DataSources()` constructor lists.
 - Each resource has a matching example at `examples/resources/<type>/resource.tf` and an `import.sh`; data sources have `examples/data-sources/<type>/data-source.tf`. These examples are embedded into the generated docs.
 - Auth lives entirely in `provider.go`'s `Configure`. The provider accepts a static `token` (env `PIPEFY_TOKEN`) or a service account `client_id` + `client_secret` (env `PIPEFY_CLIENT_ID` / `PIPEFY_CLIENT_SECRET`); exactly one mode must be configured.

--- a/internal/provider/client/api_client.go
+++ b/internal/provider/client/api_client.go
@@ -16,6 +16,7 @@ type ApiClient struct {
 	HTTP     *http.Client
 	Endpoint string
 	Token    string
+	Version  string
 }
 
 type graphQLRequest struct {
@@ -49,12 +50,12 @@ func (c *ApiClient) DoGraphQL(ctx context.Context, query string, variables map[s
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "terraform-provider-pipefy/"+c.Version)
 
 	// Only set Authorization header if we have a static token
 	// For OAuth2 client credentials, the http.Client handles this automatically
 	if c.Token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.Token)
-		fmt.Printf("DEBUG: Using static token for authorization\n")
 	}
 
 	resp, err := c.HTTP.Do(req)

--- a/internal/provider/client/api_client.go
+++ b/internal/provider/client/api_client.go
@@ -6,6 +6,8 @@ package client
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,6 +19,29 @@ type ApiClient struct {
 	Endpoint string
 	Token    string
 	Version  string
+	TraceID  string
+}
+
+// NewTraceID returns a W3C Trace Context trace-id: 16 random bytes as 32
+// lowercase hex characters. The provider is the root of the trace (Terraform
+// passes no upstream context), so one trace-id is minted per run and reused on
+// every request, grouping all of a run's API calls under a single trace.
+func NewTraceID() string { return randHex(16) }
+
+// newSpanID returns a trace-context span-id: 8 random bytes as 16 hex
+// characters, fresh per request so each call is its own span under the trace.
+func newSpanID() string { return randHex(8) }
+
+func randHex(n int) string {
+	b := make([]byte, n)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// traceparent assembles a version-00 header with the sampled flag (01) set, so
+// the backend records every provider run.
+func traceparent(traceID, spanID string) string {
+	return "00-" + traceID + "-" + spanID + "-01"
 }
 
 type graphQLRequest struct {
@@ -51,6 +76,9 @@ func (c *ApiClient) DoGraphQL(ctx context.Context, query string, variables map[s
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", "terraform-provider-pipefy/"+c.Version)
+	if c.TraceID != "" {
+		req.Header.Set("traceparent", traceparent(c.TraceID, newSpanID()))
+	}
 
 	// Only set Authorization header if we have a static token
 	// For OAuth2 client credentials, the http.Client handles this automatically

--- a/internal/provider/client/api_client_test.go
+++ b/internal/provider/client/api_client_test.go
@@ -89,6 +89,25 @@ func TestApiClient_DoGraphQL_OutNil_Succeeds(t *testing.T) {
 	}
 }
 
+func TestApiClient_DoGraphQL_UserAgentHeader(t *testing.T) {
+	var gotUA string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"ok":true}}`))
+	}))
+	defer ts.Close()
+
+	c := &ApiClient{HTTP: ts.Client(), Endpoint: ts.URL, Version: "1.2.3"}
+	if err := c.DoGraphQL(t.Context(), "query {}", nil, nil); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if want := "terraform-provider-pipefy/1.2.3"; gotUA != want {
+		t.Fatalf("User-Agent = %q, want %q", gotUA, want)
+	}
+}
+
 func TestApiClient_DoGraphQL_MissingData(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/provider/client/api_client_test.go
+++ b/internal/provider/client/api_client_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -105,6 +107,89 @@ func TestApiClient_DoGraphQL_UserAgentHeader(t *testing.T) {
 	}
 	if want := "terraform-provider-pipefy/1.2.3"; gotUA != want {
 		t.Fatalf("User-Agent = %q, want %q", gotUA, want)
+	}
+}
+
+func TestApiClient_DoGraphQL_TraceparentHeader(t *testing.T) {
+	var got string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("traceparent")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"ok":true}}`))
+	}))
+	defer ts.Close()
+
+	traceID := "4bf92f3577b34da6a3ce929d0e0e4736"
+	c := &ApiClient{HTTP: ts.Client(), Endpoint: ts.URL, TraceID: traceID}
+	if err := c.DoGraphQL(t.Context(), "query {}", nil, nil); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	re := regexp.MustCompile("^00-" + regexp.QuoteMeta(traceID) + "-[0-9a-f]{16}-01$")
+	if !re.MatchString(got) {
+		t.Fatalf("traceparent = %q, want match %s", got, re)
+	}
+}
+
+func TestApiClient_DoGraphQL_TraceparentTraceConstantSpanVaries(t *testing.T) {
+	var got []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = append(got, r.Header.Get("traceparent"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"ok":true}}`))
+	}))
+	defer ts.Close()
+
+	traceID := "4bf92f3577b34da6a3ce929d0e0e4736"
+	c := &ApiClient{HTTP: ts.Client(), Endpoint: ts.URL, TraceID: traceID}
+	for range 2 {
+		if err := c.DoGraphQL(t.Context(), "query {}", nil, nil); err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(got))
+	}
+	parts0, parts1 := strings.Split(got[0], "-"), strings.Split(got[1], "-")
+	if len(parts0) != 4 || len(parts1) != 4 {
+		t.Fatalf("malformed traceparent(s): %q, %q", got[0], got[1])
+	}
+	if parts0[1] != traceID || parts1[1] != traceID {
+		t.Fatalf("trace-id not constant across requests: %q vs %q", got[0], got[1])
+	}
+	if parts0[2] == parts1[2] {
+		t.Fatalf("span-id should differ across requests, both %q", parts0[2])
+	}
+}
+
+func TestApiClient_DoGraphQL_NoTraceparentWhenUnset(t *testing.T) {
+	var present bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, present = r.Header["Traceparent"]
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"ok":true}}`))
+	}))
+	defer ts.Close()
+
+	c := &ApiClient{HTTP: ts.Client(), Endpoint: ts.URL}
+	if err := c.DoGraphQL(t.Context(), "query {}", nil, nil); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if present {
+		t.Fatalf("traceparent header should be absent when TraceID is unset")
+	}
+}
+
+func TestNewTraceID(t *testing.T) {
+	re := regexp.MustCompile("^[0-9a-f]{32}$")
+	a, b := NewTraceID(), NewTraceID()
+	if !re.MatchString(a) {
+		t.Fatalf("NewTraceID() = %q, want 32 lowercase hex chars", a)
+	}
+	if a == b {
+		t.Fatalf("NewTraceID() returned identical values %q", a)
 	}
 }
 

--- a/internal/provider/datasources/datasource_phase.go
+++ b/internal/provider/datasources/datasource_phase.go
@@ -63,7 +63,7 @@ func (d *PhaseDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	query := "query($id:ID!){ phase(id:$id){ id name } }"
+	query := "query GetPhaseName_tf($id:ID!){ phase(id:$id){ id name } }"
 	vars := map[string]any{"id": data.Id.ValueString()}
 	var out struct {
 		Phase *struct {

--- a/internal/provider/datasources/datasource_pipe.go
+++ b/internal/provider/datasources/datasource_pipe.go
@@ -103,7 +103,7 @@ func (d *PipeDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 
-	query := "query($id:ID!){ pipe(id:$id){ " + pipegql.Selection + " organization { id } } }"
+	query := "query GetPipe_tf($id:ID!){ pipe(id:$id){ " + pipegql.Selection + " organization { id } } }"
 	var out struct {
 		Pipe *struct {
 			pipegql.Payload

--- a/internal/provider/fieldgql/fieldgql.go
+++ b/internal/provider/fieldgql/fieldgql.go
@@ -1,0 +1,25 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package fieldgql holds the GraphQL field selection and the typed phase-field
+// payload shared across the pipefy_field resource's reads and writes.
+package fieldgql
+
+const Selection = "id internal_id uuid label options"
+
+type Field struct {
+	Id         string   `json:"id"`
+	InternalId string   `json:"internal_id"`
+	Uuid       string   `json:"uuid"`
+	Label      string   `json:"label"`
+	Options    []string `json:"options"`
+}
+
+func FindByUUID(fields []Field, uuid string) (Field, bool) {
+	for _, f := range fields {
+		if f.Uuid == uuid {
+			return f, true
+		}
+	}
+	return Field{}, false
+}

--- a/internal/provider/fieldgql/fieldgql_test.go
+++ b/internal/provider/fieldgql/fieldgql_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fieldgql_test
+
+import (
+	"testing"
+
+	"github.com/pipefy/terraform-provider-pipefy/internal/provider/fieldgql"
+)
+
+func TestFindByUUID(t *testing.T) {
+	fields := []fieldgql.Field{
+		{Id: "name", Uuid: "uuid-1", Label: "Name"},
+		{Id: "email", Uuid: "uuid-2", Label: "Email"},
+	}
+	cases := map[string]struct {
+		uuid   string
+		wantId string
+		wantOk bool
+	}{
+		"first":   {"uuid-1", "name", true},
+		"second":  {"uuid-2", "email", true},
+		"missing": {"uuid-3", "", false},
+		"empty":   {"", "", false},
+	}
+	for name, c := range cases {
+		got, ok := fieldgql.FindByUUID(fields, c.uuid)
+		if ok != c.wantOk || got.Id != c.wantId {
+			t.Errorf("%s: FindByUUID(%q) = (%q,%v), want (%q,%v)", name, c.uuid, got.Id, ok, c.wantId, c.wantOk)
+		}
+	}
+}
+
+func TestFindByUUID_EmptySlice(t *testing.T) {
+	if _, ok := fieldgql.FindByUUID(nil, "uuid-1"); ok {
+		t.Error("FindByUUID(nil, ...) returned ok=true, want false")
+	}
+}

--- a/internal/provider/labelgql/labelgql.go
+++ b/internal/provider/labelgql/labelgql.go
@@ -1,0 +1,23 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package labelgql holds the GraphQL field selection and the typed label
+// payload shared across the pipefy_label resource's reads and writes.
+package labelgql
+
+const Selection = "id name color"
+
+type Label struct {
+	Id    string `json:"id"`
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+func FindByID(labels []Label, id string) (Label, bool) {
+	for _, l := range labels {
+		if l.Id == id {
+			return l, true
+		}
+	}
+	return Label{}, false
+}

--- a/internal/provider/labelgql/labelgql_test.go
+++ b/internal/provider/labelgql/labelgql_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package labelgql_test
+
+import (
+	"testing"
+
+	"github.com/pipefy/terraform-provider-pipefy/internal/provider/labelgql"
+)
+
+func TestFindByID(t *testing.T) {
+	labels := []labelgql.Label{
+		{Id: "1", Name: "Bug", Color: "#FF0000"},
+		{Id: "2", Name: "Feature", Color: "#00FF00"},
+	}
+	cases := map[string]struct {
+		id       string
+		wantName string
+		wantOk   bool
+	}{
+		"first":   {"1", "Bug", true},
+		"second":  {"2", "Feature", true},
+		"missing": {"3", "", false},
+		"empty":   {"", "", false},
+	}
+	for name, c := range cases {
+		got, ok := labelgql.FindByID(labels, c.id)
+		if ok != c.wantOk || got.Name != c.wantName {
+			t.Errorf("%s: FindByID(%q) = (%q,%v), want (%q,%v)", name, c.id, got.Name, ok, c.wantName, c.wantOk)
+		}
+	}
+}
+
+func TestFindByID_EmptySlice(t *testing.T) {
+	if _, ok := labelgql.FindByID(nil, "1"); ok {
+		t.Error("FindByID(nil, ...) returned ok=true, want false")
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -137,7 +137,7 @@ func (p *PipefyProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		return
 	}
 
-	api := &client.ApiClient{HTTP: httpClient, Endpoint: endpoint, Token: apiToken, Version: p.version}
+	api := &client.ApiClient{HTTP: httpClient, Endpoint: endpoint, Token: apiToken, Version: p.version, TraceID: client.NewTraceID()}
 
 	resp.DataSourceData = api
 	resp.ResourceData = api

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -137,11 +137,7 @@ func (p *PipefyProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		return
 	}
 
-	version := p.version
-	if version == "" {
-		version = "dev"
-	}
-	api := &client.ApiClient{HTTP: httpClient, Endpoint: endpoint, Token: apiToken, Version: version}
+	api := &client.ApiClient{HTTP: httpClient, Endpoint: endpoint, Token: apiToken, Version: p.version}
 
 	resp.DataSourceData = api
 	resp.ResourceData = api

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -137,7 +137,11 @@ func (p *PipefyProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		return
 	}
 
-	api := &client.ApiClient{HTTP: httpClient, Endpoint: endpoint, Token: apiToken}
+	version := p.version
+	if version == "" {
+		version = "dev"
+	}
+	api := &client.ApiClient{HTTP: httpClient, Endpoint: endpoint, Token: apiToken, Version: version}
 
 	resp.DataSourceData = api
 	resp.ResourceData = api

--- a/internal/provider/provider_additional_test.go
+++ b/internal/provider/provider_additional_test.go
@@ -7,7 +7,10 @@ import (
 	"testing"
 
 	frameworkprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	providerpkg "github.com/pipefy/terraform-provider-pipefy/internal/provider"
+	"github.com/pipefy/terraform-provider-pipefy/internal/provider/client"
 )
 
 func TestProvider_Metadata_TypeName(t *testing.T) {
@@ -16,6 +19,39 @@ func TestProvider_Metadata_TypeName(t *testing.T) {
 	prov.Metadata(t.Context(), frameworkprovider.MetadataRequest{}, resp)
 	if resp.TypeName != "pipefy" {
 		t.Fatalf("expected provider type name 'pipefy', got %q", resp.TypeName)
+	}
+}
+
+func TestProvider_Configure_SetsTraceID(t *testing.T) {
+	prov := providerpkg.New("test")()
+	ctx := t.Context()
+
+	schemaResp := &frameworkprovider.SchemaResponse{}
+	prov.Schema(ctx, frameworkprovider.SchemaRequest{}, schemaResp)
+
+	raw := tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), map[string]tftypes.Value{
+		"endpoint":      tftypes.NewValue(tftypes.String, nil),
+		"token":         tftypes.NewValue(tftypes.String, nil),
+		"client_id":     tftypes.NewValue(tftypes.String, nil),
+		"client_secret": tftypes.NewValue(tftypes.String, nil),
+		"token_url":     tftypes.NewValue(tftypes.String, nil),
+	})
+	t.Setenv("PIPEFY_TOKEN", "test-token")
+
+	resp := &frameworkprovider.ConfigureResponse{}
+	prov.Configure(ctx, frameworkprovider.ConfigureRequest{
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: raw},
+	}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	api, ok := resp.ResourceData.(*client.ApiClient)
+	if !ok {
+		t.Fatalf("ResourceData = %T, want *client.ApiClient", resp.ResourceData)
+	}
+	if api.TraceID == "" {
+		t.Fatalf("expected Configure to set a trace-id, got empty")
 	}
 }
 

--- a/internal/provider/resources/resource_automation.go
+++ b/internal/provider/resources/resource_automation.go
@@ -84,7 +84,7 @@ func (r *AutomationResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	mutation := "mutation($input:CreateAutomationInput!){ createAutomation(input:$input){ automation{ id name action_id event_id active } error_details{ object_name object_key messages } } }"
+	mutation := "mutation CreateAutomation_tf($input:CreateAutomationInput!){ createAutomation(input:$input){ automation{ id name action_id event_id active } error_details{ object_name object_key messages } } }"
 	input := map[string]any{
 		"name":           data.Name.ValueString(),
 		"action_id":      data.ActionId.ValueString(),
@@ -157,7 +157,7 @@ func (r *AutomationResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	query := "query($id:ID!){ automation(id:$id){ id name action_id event_id active event_repo{ id } action_repo_v2{ ... on Pipe{ id } ... on Table{ id } } } }"
+	query := "query GetAutomation_tf($id:ID!){ automation(id:$id){ id name action_id event_id active event_repo{ id } action_repo_v2{ ... on Pipe{ id } ... on Table{ id } } } }"
 	vars := map[string]any{"id": data.Id.ValueString()}
 	var out struct {
 		Automation *struct {
@@ -192,7 +192,7 @@ func (r *AutomationResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	mutation := "mutation($input:UpdateAutomationInput!){ updateAutomation(input:$input){ automation{ id } error_details{ object_name object_key messages } } }"
+	mutation := "mutation UpdateAutomation_tf($input:UpdateAutomationInput!){ updateAutomation(input:$input){ automation{ id } error_details{ object_name object_key messages } } }"
 	input := map[string]any{
 		"id": data.Id.ValueString(),
 	}
@@ -265,7 +265,7 @@ func (r *AutomationResource) Delete(ctx context.Context, req resource.DeleteRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	mutation := "mutation($id:ID!){ deleteAutomation(input:{id:$id}){ success } }"
+	mutation := "mutation DeleteAutomation_tf($id:ID!){ deleteAutomation(input:{id:$id}){ success } }"
 	vars := map[string]any{"id": data.Id.ValueString()}
 	var out struct {
 		DeleteAutomation struct {

--- a/internal/provider/resources/resource_field.go
+++ b/internal/provider/resources/resource_field.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/pipefy/terraform-provider-pipefy/internal/provider/client"
+	"github.com/pipefy/terraform-provider-pipefy/internal/provider/fieldgql"
 	"github.com/pipefy/terraform-provider-pipefy/internal/provider/locks"
 )
 
@@ -105,7 +106,7 @@ func (r *FieldResource) Create(ctx context.Context, req resource.CreateRequest, 
 	unlock := locks.LockRepo(repoIDStr)
 	defer unlock()
 
-	mutation := "mutation($phaseId:ID!,$type:ID!,$label:String!,$required:Boolean,$options:[String]){ createPhaseField(input:{ phase_id:$phaseId, type:$type, label:$label, required:$required, options:$options }){ phase_field{ id internal_id uuid label options } } }"
+	mutation := "mutation($phaseId:ID!,$type:ID!,$label:String!,$required:Boolean,$options:[String]){ createPhaseField(input:{ phase_id:$phaseId, type:$type, label:$label, required:$required, options:$options }){ phase_field{ " + fieldgql.Selection + " } } }"
 	vars := map[string]any{
 		"phaseId": data.PhaseId.ValueString(),
 		"type":    data.Type.ValueString(),
@@ -124,13 +125,7 @@ func (r *FieldResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 	var out struct {
 		CreatePhaseField struct {
-			PhaseField struct {
-				Id         string   `json:"id"`
-				InternalId string   `json:"internal_id"`
-				Uuid       string   `json:"uuid"`
-				Label      string   `json:"label"`
-				Options    []string `json:"options"`
-			} `json:"phase_field"`
+			PhaseField fieldgql.Field `json:"phase_field"`
 		} `json:"createPhaseField"`
 	}
 	if err := r.api.DoGraphQL(ctx, mutation, vars, &out); err != nil {
@@ -155,17 +150,11 @@ func (r *FieldResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 
 	// Query the phase to get the field information
-	query := "query($phaseId:ID!){ phase(id:$phaseId){ fields{ id internal_id uuid label options } } }"
+	query := "query($phaseId:ID!){ phase(id:$phaseId){ fields{ " + fieldgql.Selection + " } } }"
 	vars := map[string]any{"phaseId": data.PhaseId.ValueString()}
 	var out struct {
 		Phase *struct {
-			Fields []struct {
-				Id         string   `json:"id"`
-				InternalId string   `json:"internal_id"`
-				Uuid       string   `json:"uuid"`
-				Label      string   `json:"label"`
-				Options    []string `json:"options"`
-			} `json:"fields"`
+			Fields []fieldgql.Field `json:"fields"`
 		} `json:"phase"`
 	}
 	if err := r.api.DoGraphQL(ctx, query, vars, &out); err != nil {
@@ -177,29 +166,16 @@ func (r *FieldResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	var foundField *struct {
-		Id         string   `json:"id"`
-		InternalId string   `json:"internal_id"`
-		Uuid       string   `json:"uuid"`
-		Label      string   `json:"label"`
-		Options    []string `json:"options"`
-	}
-	for i := range out.Phase.Fields {
-		if out.Phase.Fields[i].Uuid == data.Uuid.ValueString() {
-			foundField = &out.Phase.Fields[i]
-			break
-		}
-	}
-
-	if foundField == nil {
+	found, ok := fieldgql.FindByUUID(out.Phase.Fields, data.Uuid.ValueString())
+	if !ok {
 		resp.State.RemoveResource(ctx)
 		return
 	}
 
-	data.Id = types.StringValue(foundField.Id)
-	data.InternalId = types.StringValue(foundField.InternalId)
-	data.Uuid = types.StringValue(foundField.Uuid)
-	data.Options = optionsToList(ctx, foundField.Options, &resp.Diagnostics)
+	data.Id = types.StringValue(found.Id)
+	data.InternalId = types.StringValue(found.InternalId)
+	data.Uuid = types.StringValue(found.Uuid)
+	data.Options = optionsToList(ctx, found.Options, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -231,11 +207,7 @@ func (r *FieldResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 	var out struct {
 		UpdatePhaseField struct {
-			PhaseField struct {
-				Id         string   `json:"id"`
-				InternalId string   `json:"internal_id"`
-				Options    []string `json:"options"`
-			} `json:"phase_field"`
+			PhaseField fieldgql.Field `json:"phase_field"`
 		} `json:"updatePhaseField"`
 	}
 	if err := r.api.DoGraphQL(ctx, mutation, vars, &out); err != nil {

--- a/internal/provider/resources/resource_field.go
+++ b/internal/provider/resources/resource_field.go
@@ -86,7 +86,7 @@ func (r *FieldResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	// Resolve repo_id from the phase to lock per repo
 	// pipefy api does not allow multiple field creations at the same time for the same repo
-	phaseQuery := "query($id:ID!){ phase(id:$id){ repo_id } }"
+	phaseQuery := "query GetPhaseRepoId_tf($id:ID!){ phase(id:$id){ repo_id } }"
 	phaseVars := map[string]any{"id": data.PhaseId.ValueString()}
 	var phaseOut struct {
 		Phase *struct {
@@ -106,7 +106,7 @@ func (r *FieldResource) Create(ctx context.Context, req resource.CreateRequest, 
 	unlock := locks.LockRepo(repoIDStr)
 	defer unlock()
 
-	mutation := "mutation($phaseId:ID!,$type:ID!,$label:String!,$required:Boolean,$options:[String]){ createPhaseField(input:{ phase_id:$phaseId, type:$type, label:$label, required:$required, options:$options }){ phase_field{ " + fieldgql.Selection + " } } }"
+	mutation := "mutation CreatePhaseField_tf($phaseId:ID!,$type:ID!,$label:String!,$required:Boolean,$options:[String]){ createPhaseField(input:{ phase_id:$phaseId, type:$type, label:$label, required:$required, options:$options }){ phase_field{ " + fieldgql.Selection + " } } }"
 	vars := map[string]any{
 		"phaseId": data.PhaseId.ValueString(),
 		"type":    data.Type.ValueString(),
@@ -150,7 +150,7 @@ func (r *FieldResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 
 	// Query the phase to get the field information
-	query := "query($phaseId:ID!){ phase(id:$phaseId){ fields{ " + fieldgql.Selection + " } } }"
+	query := "query GetPhaseFields_tf($phaseId:ID!){ phase(id:$phaseId){ fields{ " + fieldgql.Selection + " } } }"
 	vars := map[string]any{"phaseId": data.PhaseId.ValueString()}
 	var out struct {
 		Phase *struct {
@@ -185,7 +185,7 @@ func (r *FieldResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	mutation := "mutation($id:ID!,$uuid:ID!,$label:String!,$required:Boolean,$options:[String]){ updatePhaseField(input:{ id:$id, uuid:$uuid, label:$label, required:$required, options:$options }){ phase_field{ id internal_id options } } }"
+	mutation := "mutation UpdatePhaseField_tf($id:ID!,$uuid:ID!,$label:String!,$required:Boolean,$options:[String]){ updatePhaseField(input:{ id:$id, uuid:$uuid, label:$label, required:$required, options:$options }){ phase_field{ id internal_id options } } }"
 	vars := map[string]any{
 		"id":   data.Id.ValueString(),
 		"uuid": data.Uuid.ValueString(),
@@ -227,7 +227,7 @@ func (r *FieldResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	}
 
 	// Fetch repo_id from the phase
-	phaseQuery := "query($id:ID!){ phase(id:$id){ repo_id } }"
+	phaseQuery := "query GetPhaseRepoId_tf($id:ID!){ phase(id:$id){ repo_id } }"
 	phaseVars := map[string]any{"id": data.PhaseId.ValueString()}
 	var phaseOut struct {
 		Phase *struct {
@@ -249,7 +249,7 @@ func (r *FieldResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	}
 
 	// Fetch pipe uuid with repo_id
-	pipeQuery := "query($id:ID!){ pipe(id:$id){ uuid } }"
+	pipeQuery := "query GetPipeUuid_tf($id:ID!){ pipe(id:$id){ uuid } }"
 	pipeVars := map[string]any{"id": repoIDStr}
 	var pipeOut struct {
 		Pipe *struct {
@@ -265,7 +265,7 @@ func (r *FieldResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		return
 	}
 
-	mutation := "mutation($id:ID!,$pipeUuid:ID!){ deletePhaseField(input:{ id:$id, pipeUuid:$pipeUuid }){ success } }"
+	mutation := "mutation DeletePhaseField_tf($id:ID!,$pipeUuid:ID!){ deletePhaseField(input:{ id:$id, pipeUuid:$pipeUuid }){ success } }"
 	vars := map[string]any{"id": data.Id.ValueString(), "pipeUuid": pipeOut.Pipe.Uuid}
 	var out struct {
 		DeletePhaseField struct {

--- a/internal/provider/resources/resource_label.go
+++ b/internal/provider/resources/resource_label.go
@@ -73,7 +73,7 @@ func (r *LabelResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	mutation := "mutation($pipeId:ID!,$name:String!,$color:String!){ createLabel(input:{ pipe_id:$pipeId, name:$name, color:$color }){ label{ " + labelgql.Selection + " } } }"
+	mutation := "mutation CreateLabel_tf($pipeId:ID!,$name:String!,$color:String!){ createLabel(input:{ pipe_id:$pipeId, name:$name, color:$color }){ label{ " + labelgql.Selection + " } } }"
 	vars := map[string]any{
 		"pipeId": data.PipeId.ValueString(),
 		"name":   data.Name.ValueString(),
@@ -104,7 +104,7 @@ func (r *LabelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	query := "query($pipeId:ID!){ pipe(id:$pipeId){ labels{ " + labelgql.Selection + " } } }"
+	query := "query GetPipeLabels_tf($pipeId:ID!){ pipe(id:$pipeId){ labels{ " + labelgql.Selection + " } } }"
 	vars := map[string]any{"pipeId": data.PipeId.ValueString()}
 	var out struct {
 		Pipe *struct {
@@ -137,7 +137,7 @@ func (r *LabelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	mutation := "mutation($id:ID!,$name:String!,$color:String!){ updateLabel(input:{ id:$id, name:$name, color:$color }){ label{ " + labelgql.Selection + " } } }"
+	mutation := "mutation UpdateLabel_tf($id:ID!,$name:String!,$color:String!){ updateLabel(input:{ id:$id, name:$name, color:$color }){ label{ " + labelgql.Selection + " } } }"
 	vars := map[string]any{
 		"id":    data.Id.ValueString(),
 		"name":  data.Name.ValueString(),
@@ -163,7 +163,7 @@ func (r *LabelResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	mutation := "mutation($id:ID!){ deleteLabel(input:{ id:$id }){ success } }"
+	mutation := "mutation DeleteLabel_tf($id:ID!){ deleteLabel(input:{ id:$id }){ success } }"
 	vars := map[string]any{"id": data.Id.ValueString()}
 	var out struct {
 		DeleteLabel struct {

--- a/internal/provider/resources/resource_label.go
+++ b/internal/provider/resources/resource_label.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/pipefy/terraform-provider-pipefy/internal/provider/client"
+	"github.com/pipefy/terraform-provider-pipefy/internal/provider/labelgql"
 	"github.com/pipefy/terraform-provider-pipefy/internal/provider/validators"
 )
 
@@ -72,7 +73,7 @@ func (r *LabelResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	mutation := "mutation($pipeId:ID!,$name:String!,$color:String!){ createLabel(input:{ pipe_id:$pipeId, name:$name, color:$color }){ label{ id name color } } }"
+	mutation := "mutation($pipeId:ID!,$name:String!,$color:String!){ createLabel(input:{ pipe_id:$pipeId, name:$name, color:$color }){ label{ " + labelgql.Selection + " } } }"
 	vars := map[string]any{
 		"pipeId": data.PipeId.ValueString(),
 		"name":   data.Name.ValueString(),
@@ -80,11 +81,7 @@ func (r *LabelResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 	var out struct {
 		CreateLabel struct {
-			Label struct {
-				Id    string `json:"id"`
-				Name  string `json:"name"`
-				Color string `json:"color"`
-			} `json:"label"`
+			Label labelgql.Label `json:"label"`
 		} `json:"createLabel"`
 	}
 	if err := r.api.DoGraphQL(ctx, mutation, vars, &out); err != nil {
@@ -107,15 +104,11 @@ func (r *LabelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	query := "query($pipeId:ID!){ pipe(id:$pipeId){ labels{ id name color } } }"
+	query := "query($pipeId:ID!){ pipe(id:$pipeId){ labels{ " + labelgql.Selection + " } } }"
 	vars := map[string]any{"pipeId": data.PipeId.ValueString()}
 	var out struct {
 		Pipe *struct {
-			Labels []struct {
-				Id    string `json:"id"`
-				Name  string `json:"name"`
-				Color string `json:"color"`
-			} `json:"labels"`
+			Labels []labelgql.Label `json:"labels"`
 		} `json:"pipe"`
 	}
 	if err := r.api.DoGraphQL(ctx, query, vars, &out); err != nil {
@@ -127,16 +120,14 @@ func (r *LabelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	id := data.Id.ValueString()
-	for _, l := range out.Pipe.Labels {
-		if l.Id == id {
-			data.Name = types.StringValue(l.Name)
-			data.Color = types.StringValue(l.Color)
-			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-			return
-		}
+	l, ok := labelgql.FindByID(out.Pipe.Labels, data.Id.ValueString())
+	if !ok {
+		resp.State.RemoveResource(ctx)
+		return
 	}
-	resp.State.RemoveResource(ctx)
+	data.Name = types.StringValue(l.Name)
+	data.Color = types.StringValue(l.Color)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *LabelResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -146,7 +137,7 @@ func (r *LabelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	mutation := "mutation($id:ID!,$name:String!,$color:String!){ updateLabel(input:{ id:$id, name:$name, color:$color }){ label{ id name color } } }"
+	mutation := "mutation($id:ID!,$name:String!,$color:String!){ updateLabel(input:{ id:$id, name:$name, color:$color }){ label{ " + labelgql.Selection + " } } }"
 	vars := map[string]any{
 		"id":    data.Id.ValueString(),
 		"name":  data.Name.ValueString(),
@@ -154,11 +145,7 @@ func (r *LabelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 	var out struct {
 		UpdateLabel struct {
-			Label struct {
-				Id    string `json:"id"`
-				Name  string `json:"name"`
-				Color string `json:"color"`
-			} `json:"label"`
+			Label labelgql.Label `json:"label"`
 		} `json:"updateLabel"`
 	}
 	if err := r.api.DoGraphQL(ctx, mutation, vars, &out); err != nil {

--- a/internal/provider/resources/resource_phase.go
+++ b/internal/provider/resources/resource_phase.go
@@ -226,7 +226,7 @@ func (r *PhaseResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	mutation := "mutation DeletePhase_tf($id:ID!){ deletePhase(input:{ id:$id }){ success } }"
+	mutation := "mutation DeletePhase_tf($id:ID!){ deletePhase(input:{id:$id}){ success } }"
 	vars := map[string]any{"id": data.Id.ValueString()}
 	var out struct {
 		DeletePhase struct {

--- a/internal/provider/resources/resource_phase.go
+++ b/internal/provider/resources/resource_phase.go
@@ -149,7 +149,7 @@ func (r *PhaseResource) Create(ctx context.Context, req resource.CreateRequest, 
 	unlock := locks.LockRepo(data.PipeId.ValueString())
 	defer unlock()
 
-	mutation := "mutation($pipeId:ID!,$name:String!,$done:Boolean,$description:String,$index:Float,$latenessTime:Int,$canReceiveCardDirectlyFromDraft:Boolean){ createPhase(input:{ pipe_id:$pipeId, name:$name, done:$done, description:$description, index:$index, lateness_time:$latenessTime, can_receive_card_directly_from_draft:$canReceiveCardDirectlyFromDraft }){ phase{ " + phaseSelection + " } } }"
+	mutation := "mutation CreatePhase_tf($pipeId:ID!,$name:String!,$done:Boolean,$description:String,$index:Float,$latenessTime:Int,$canReceiveCardDirectlyFromDraft:Boolean){ createPhase(input:{ pipe_id:$pipeId, name:$name, done:$done, description:$description, index:$index, lateness_time:$latenessTime, can_receive_card_directly_from_draft:$canReceiveCardDirectlyFromDraft }){ phase{ " + phaseSelection + " } } }"
 	vars := map[string]any{"pipeId": data.PipeId.ValueString(), "name": data.Name.ValueString()}
 	data.addSharedPhaseVars(vars)
 	if hasValue(data.Index) {
@@ -181,7 +181,7 @@ func (r *PhaseResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	query := "query($id:ID!){ phase(id:$id){ " + phaseSelection + " } }"
+	query := "query GetPhase_tf($id:ID!){ phase(id:$id){ " + phaseSelection + " } }"
 	vars := map[string]any{"id": data.Id.ValueString()}
 	var out struct {
 		Phase *phasePayload `json:"phase"`
@@ -204,7 +204,7 @@ func (r *PhaseResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	mutation := "mutation($id:ID!,$name:String!,$done:Boolean,$description:String,$latenessTime:Int,$canReceiveCardDirectlyFromDraft:Boolean){ updatePhase(input:{ id:$id, name:$name, done:$done, description:$description, lateness_time:$latenessTime, can_receive_card_directly_from_draft:$canReceiveCardDirectlyFromDraft }){ phase{ " + phaseSelection + " } } }"
+	mutation := "mutation UpdatePhase_tf($id:ID!,$name:String!,$done:Boolean,$description:String,$latenessTime:Int,$canReceiveCardDirectlyFromDraft:Boolean){ updatePhase(input:{ id:$id, name:$name, done:$done, description:$description, lateness_time:$latenessTime, can_receive_card_directly_from_draft:$canReceiveCardDirectlyFromDraft }){ phase{ " + phaseSelection + " } } }"
 	vars := map[string]any{"id": data.Id.ValueString(), "name": data.Name.ValueString()}
 	data.addSharedPhaseVars(vars)
 	var out struct {
@@ -226,7 +226,7 @@ func (r *PhaseResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	mutation := "mutation($id:ID!){ deletePhase(input:{ id:$id }){ success } }"
+	mutation := "mutation DeletePhase_tf($id:ID!){ deletePhase(input:{ id:$id }){ success } }"
 	vars := map[string]any{"id": data.Id.ValueString()}
 	var out struct {
 		DeletePhase struct {

--- a/internal/provider/resources/resource_pipe.go
+++ b/internal/provider/resources/resource_pipe.go
@@ -53,7 +53,7 @@ type PipeModel struct {
 	StartFormPhaseId          types.String          `tfsdk:"start_form_phase_id"`
 }
 
-const updatePipeMutation = "mutation($id:ID!,$name:String,$public:Boolean,$icon:String,$color:Colors," +
+const updatePipeMutation = "mutation UpdatePipe_tf($id:ID!,$name:String,$public:Boolean,$icon:String,$color:Colors," +
 	"$onlyAdminCanRemoveCards:Boolean,$onlyAssigneesCanEditCards:Boolean," +
 	"$expirationTimeByUnit:Int,$expirationUnit:Int,$preferences:RepoPreferenceInput){ " +
 	"updatePipe(input:{ id:$id, name:$name, public:$public, icon:$icon, color:$color, " +
@@ -237,7 +237,7 @@ func (m *PipeModel) addSettingsVars(ctx context.Context, vars map[string]any) di
 }
 
 func (r *PipeResource) deletePhases(ctx context.Context, ids []string) error {
-	const mutation = "mutation($id:ID!){ deletePhase(input:{id:$id}){ clientMutationId success } }"
+	const mutation = "mutation DeletePhase_tf($id:ID!){ deletePhase(input:{id:$id}){ clientMutationId success } }"
 	for _, id := range ids {
 		var del struct {
 			DeletePhase struct {
@@ -261,7 +261,7 @@ func (r *PipeResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	mutation := "mutation($name:String!,$orgId:ID!){ createPipe(input:{name:$name, organization_id:$orgId}){ pipe{ id name } } }"
+	mutation := "mutation CreatePipe_tf($name:String!,$orgId:ID!){ createPipe(input:{name:$name, organization_id:$orgId}){ pipe{ id name } } }"
 	var created struct {
 		CreatePipe struct {
 			Pipe struct {
@@ -284,7 +284,7 @@ func (r *PipeResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	// createPipe seeds the pipe with three default phases. Fetch them alongside the
 	// current settings so they can be removed and the payload reused below.
-	phasesQuery := "query($id:ID!){ pipe(id:$id){ " + pipegql.Selection + " phases { id } } }"
+	phasesQuery := "query GetPipePhases_tf($id:ID!){ pipe(id:$id){ " + pipegql.Selection + " phases { id } } }"
 	var phasesOut struct {
 		Pipe *struct {
 			pipegql.Payload
@@ -347,7 +347,7 @@ func (r *PipeResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	query := "query($id:ID!){ pipe(id:$id){ " + pipegql.Selection + " organization { id } } }"
+	query := "query GetPipe_tf($id:ID!){ pipe(id:$id){ " + pipegql.Selection + " organization { id } } }"
 	var out struct {
 		Pipe *struct {
 			pipegql.Payload
@@ -402,7 +402,7 @@ func (r *PipeResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	mutation := "mutation($id:ID!){ deletePipe(input:{id:$id}){ success } }"
+	mutation := "mutation DeletePipe_tf($id:ID!){ deletePipe(input:{id:$id}){ success } }"
 	var out struct {
 		DeletePipe struct {
 			Success bool `json:"success"`

--- a/internal/provider/resources/resource_pipe.go
+++ b/internal/provider/resources/resource_pipe.go
@@ -237,7 +237,7 @@ func (m *PipeModel) addSettingsVars(ctx context.Context, vars map[string]any) di
 }
 
 func (r *PipeResource) deletePhases(ctx context.Context, ids []string) error {
-	const mutation = "mutation DeletePhase_tf($id:ID!){ deletePhase(input:{id:$id}){ clientMutationId success } }"
+	const mutation = "mutation DeletePhase_tf($id:ID!){ deletePhase(input:{id:$id}){ success } }"
 	for _, id := range ids {
 		var del struct {
 			DeletePhase struct {


### PR DESCRIPTION
## What this does

Three changes, one commit each.

### Add a provider User-Agent header (closes #71)

`DoGraphQL` now sets `User-Agent: terraform-provider-pipefy/<version>` on every request. It is the single chokepoint, so both the static-token and OAuth2 client-credentials transports are covered. The version flows from `provider.version` into `ApiClient`; `main.go` defaults it to `dev`. A stray debug `Printf` in `DoGraphQL` is removed.

### Name GraphQL operations with a _tf marker

Every query and mutation now carries a descriptive name with a `_tf` suffix (`query GetPipe_tf(...)`, `mutation CreateLabel_tf(...)`): `Get*` for queries, `Create*` / `Update*` / `Delete*` for mutations. Anonymous operations cannot be told apart in server-side traces; the name groups them per operation and the `_tf` suffix flags them as provider traffic, alongside the User-Agent header. Apart from the inserted name, request bodies are unchanged, with one exception: the two `deletePhase` mutations (`resource_pipe.go` and `resource_phase.go`) are unified into a single `DeletePhase_tf` body. The unification drops an unused `clientMutationId` from the `resource_pipe.go` selection and normalizes the `input:{ id:$id }` whitespace in `resource_phase.go`. No struct decoded `clientMutationId`, so the change has no behavioral effect. The convention is documented in `AGENTS.md`.

### Refactor field and label reads

`resource_field.go` and `resource_label.go` decoded responses into anonymous structs (the field struct appeared three times) and found the managed record with an inline loop. This extracts:

- typed payloads `fieldgql.Field` and `labelgql.Label`, replacing the anonymous structs,
- a shared `Selection` fragment per domain,
- pure `FindByUUID` and `FindByID` lookups, each with unit tests.

The pattern matches the existing `pipegql` package: the domain package owns the selection fragment, the typed payload, and the pure logic, while the `types.*` assignment stays in the resource.

## Testing

`go build ./...`, `go vet ./...`, `gofmt -l`, `go test ./...`, and `golangci-lint run` all pass. `make generate` produces no diff.

Apart from the inserted name and the unified `DeletePhase_tf` body noted above, request bodies are unchanged: the names are inserted after `query` / `mutation`, and the selection fragments expand byte-identically. The resource acceptance tests are gated on `TF_ACC` and were not run against the live API, so the decode-struct change is verified by json-tag identity with the previous anonymous structs rather than by execution.
