### PR TITLE
Surface automation error_details as diagnostics

### DIFF
--- a/internal/provider/client/api_client.go
+++ b/internal/provider/client/api_client.go
@@ -127,9 +127,6 @@ func (c *ApiClient) DoGraphQL(ctx context.Context, query string, variables map[s
 	if out != nil && len(gqlResp.Data) > 0 {
 		decodeErr = json.Unmarshal(gqlResp.Data, out)
 	}
-	// Top-level errors take precedence over a data-decode mismatch: a rejected
-	// request can still return a payload whose shape differs from the query
-	// selection, and the GraphQL message is the useful one.
 	if len(gqlResp.Errors) > 0 {
 		messages := make([]string, len(gqlResp.Errors))
 		for i, e := range gqlResp.Errors {

--- a/internal/provider/client/api_client.go
+++ b/internal/provider/client/api_client.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 type ApiClient struct {
@@ -58,20 +59,20 @@ type graphQLResponse struct {
 	Errors []graphQLError  `json:"errors"`
 }
 
-func (c *ApiClient) DoGraphQL(ctx context.Context, query string, variables map[string]any, out any) error {
+func (c *ApiClient) execGraphQL(ctx context.Context, query string, variables map[string]any) (*graphQLResponse, error) {
 	if c.HTTP == nil {
-		return fmt.Errorf("api client http is nil")
+		return nil, fmt.Errorf("api client http is nil")
 	}
 	if c.Endpoint == "" {
-		return fmt.Errorf("api endpoint is empty")
+		return nil, fmt.Errorf("api endpoint is empty")
 	}
 	bodyBytes, err := json.Marshal(graphQLRequest{Query: query, Variables: variables})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.Endpoint, bytes.NewReader(bodyBytes))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
@@ -88,17 +89,17 @@ func (c *ApiClient) DoGraphQL(ctx context.Context, query string, variables map[s
 
 	resp, err := c.HTTP.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Check for non-2xx status codes first
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("graphql http status %d (content-type=%s): %s", resp.StatusCode, resp.Header.Get("Content-Type"), string(respBody))
+		return nil, fmt.Errorf("graphql http status %d (content-type=%s): %s", resp.StatusCode, resp.Header.Get("Content-Type"), string(respBody))
 	}
 
 	var gqlResp graphQLResponse
@@ -107,17 +108,40 @@ func (c *ApiClient) DoGraphQL(ctx context.Context, query string, variables map[s
 		if len(responsePreview) > 200 {
 			responsePreview = responsePreview[:200] + "..."
 		}
-		return fmt.Errorf("failed to parse JSON response (status %d): %s. Response preview: %s", resp.StatusCode, err.Error(), responsePreview)
+		return nil, fmt.Errorf("failed to parse JSON response (status %d): %s. Response preview: %s", resp.StatusCode, err.Error(), responsePreview)
 	}
+	return &gqlResp, nil
+}
 
+// DoGraphQL runs the query and decodes data into out. It unmarshals data
+// whenever the response carries it, even alongside top-level errors, so a
+// caller can read a payload the API returns with the errors (such as a
+// mutation's error_details). out is therefore populated even when this returns
+// an error. The error joins all top-level GraphQL error messages.
+func (c *ApiClient) DoGraphQL(ctx context.Context, query string, variables map[string]any, out any) error {
+	gqlResp, err := c.execGraphQL(ctx, query, variables)
+	if err != nil {
+		return err
+	}
+	var decodeErr error
+	if out != nil && len(gqlResp.Data) > 0 {
+		decodeErr = json.Unmarshal(gqlResp.Data, out)
+	}
+	// Top-level errors take precedence over a data-decode mismatch: a rejected
+	// request can still return a payload whose shape differs from the query
+	// selection, and the GraphQL message is the useful one.
 	if len(gqlResp.Errors) > 0 {
-		return fmt.Errorf("graphql error: %s", gqlResp.Errors[0].Message)
+		messages := make([]string, len(gqlResp.Errors))
+		for i, e := range gqlResp.Errors {
+			messages[i] = e.Message
+		}
+		return fmt.Errorf("graphql error: %s", strings.Join(messages, "; "))
 	}
-	if out == nil {
-		return nil
+	if decodeErr != nil {
+		return decodeErr
 	}
-	if len(gqlResp.Data) == 0 {
+	if out != nil && len(gqlResp.Data) == 0 {
 		return fmt.Errorf("graphql response missing data")
 	}
-	return json.Unmarshal(gqlResp.Data, out)
+	return nil
 }

--- a/internal/provider/client/api_client_test.go
+++ b/internal/provider/client/api_client_test.go
@@ -193,6 +193,61 @@ func TestNewTraceID(t *testing.T) {
 	}
 }
 
+func TestApiClient_DoGraphQL_DataAndErrors(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"hello":"world"},"errors":[{"message":"boom"},{"message":"bang"}]}`))
+	}))
+	defer ts.Close()
+
+	c := &ApiClient{HTTP: ts.Client(), Endpoint: ts.URL}
+	var out echoData
+	err := c.DoGraphQL(t.Context(), "query {}", nil, &out)
+	if err == nil || err.Error() != "graphql error: boom; bang" {
+		t.Fatalf("expected joined graphql error, got: %v", err)
+	}
+	if out.Hello != "world" {
+		t.Fatalf("expected data unmarshaled despite top-level errors, got: %+v", out)
+	}
+}
+
+func TestApiClient_DoGraphQL_DataDecodeMismatchYieldsToErrors(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		// hello is typed string in echoData; a number can't decode into it.
+		_, _ = w.Write([]byte(`{"data":{"hello":42},"errors":[{"message":"boom"}]}`))
+	}))
+	defer ts.Close()
+
+	c := &ApiClient{HTTP: ts.Client(), Endpoint: ts.URL}
+	var out echoData
+	err := c.DoGraphQL(t.Context(), "query {}", nil, &out)
+	if err == nil || err.Error() != "graphql error: boom" {
+		t.Fatalf("expected top-level error to win over decode mismatch, got: %v", err)
+	}
+}
+
+func TestApiClient_DoGraphQL_DataNullWithErrors(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":null,"errors":[{"message":"unauthorized"}]}`))
+	}))
+	defer ts.Close()
+
+	c := &ApiClient{HTTP: ts.Client(), Endpoint: ts.URL}
+	var out echoData
+	err := c.DoGraphQL(t.Context(), "query {}", nil, &out)
+	if err == nil || err.Error() != "graphql error: unauthorized" {
+		t.Fatalf("expected graphql error, got: %v", err)
+	}
+	if out.Hello != "" {
+		t.Fatalf("expected out untouched on data:null, got: %+v", out)
+	}
+}
+
 func TestApiClient_DoGraphQL_MissingData(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/provider/resource_automation_test.go
+++ b/internal/provider/resource_automation_test.go
@@ -45,7 +45,6 @@ func TestUnit_AutomationResource_CRUD(t *testing.T) {
 		q := gr.Query
 		switch {
 		case strings.Contains(q, "createAutomation"):
-			// input is nested under variables["input"]
 			if in, ok := gr.Variables["input"].(map[string]any); ok {
 				if v, ok2 := in["event_params"]; ok2 {
 					st.CreatedEventParams = v
@@ -70,7 +69,6 @@ func TestUnit_AutomationResource_CRUD(t *testing.T) {
 			st.DeletedCt++
 			_, _ = io.WriteString(w, `{"data":{"deleteAutomation":{"success":true}}}`)
 		case strings.Contains(q, "automation("):
-			// Read path
 			_, _ = io.WriteString(w, `{"data":{"automation":{"id":"`+st.ID+`","name":"When Summary changes, generate AI output","action_id":"generate_with_ai","event_id":"field_updated","active":true,"event_repo":{"id":"repo"},"action_repo_v2":{"id":"repo"}}}}`)
 		default:
 			_, _ = io.WriteString(w, `{"data":{}}`)
@@ -175,8 +173,6 @@ func TestUnit_AutomationResource_CreateSurfacesErrorDetails(t *testing.T) {
 		_ = json.Unmarshal(b, &gr)
 		w.Header().Set("Content-Type", "application/json")
 		if strings.Contains(gr.Query, "createAutomation") {
-			// The live API returns error_details inside data alongside a generic
-			// top-level error; the specific error_details messages must win.
 			_, _ = io.WriteString(w, `{"errors":[{"message":"All fields must be filled properly."}],"data":{"createAutomation":{"automation":null,"error_details":[{"object_name":"field_map","object_key":"420173432","messages":["can't be blank"]}]}}}`)
 			return
 		}
@@ -225,8 +221,6 @@ func TestUnit_AutomationResource_CreateSurfacesTopLevelErrors(t *testing.T) {
 		_ = json.Unmarshal(b, &gr)
 		w.Header().Set("Content-Type", "application/json")
 		if strings.Contains(gr.Query, "createAutomation") {
-			// No error_details, only top-level errors: every message surfaces,
-			// not just the first.
 			_, _ = io.WriteString(w, `{"errors":[{"message":"Name can't be blank"},{"message":"Event is invalid"}],"data":{"createAutomation":{"automation":null}}}`)
 			return
 		}

--- a/internal/provider/resource_automation_test.go
+++ b/internal/provider/resource_automation_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -164,4 +165,164 @@ func TestUnit_AutomationResource_CRUD(t *testing.T) {
 	if st.DeletedCt == 0 {
 		t.Fatalf("expected delete mutation to be called")
 	}
+}
+
+func TestUnit_AutomationResource_CreateSurfacesErrorDetails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var gr gqlReq
+		defer r.Body.Close()
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gr)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(gr.Query, "createAutomation") {
+			// The live API returns error_details inside data alongside a generic
+			// top-level error; the specific error_details messages must win.
+			_, _ = io.WriteString(w, `{"errors":[{"message":"All fields must be filled properly."}],"data":{"createAutomation":{"automation":null,"error_details":[{"object_name":"field_map","object_key":"420173432","messages":["can't be blank"]}]}}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":{}}`)
+	}))
+	defer srv.Close()
+
+	config := `
+	provider "pipefy" {
+		endpoint = "` + srv.URL + `"
+		token    = "testtoken"
+	}
+
+	resource "pipefy_automation" "test" {
+		name           = "Invalid automation"
+		event_id       = "field_updated"
+		action_id      = "update_card_field"
+		event_repo_id  = "306729113"
+		action_repo_id = "306729113"
+
+		action_params = jsonencode({
+			field_map = [{ fieldId = "420173432", inputMode = "fixed_value", value = "" }]
+		})
+	}
+	`
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`field_map.*can't be blank`),
+			},
+		},
+	})
+}
+
+func TestUnit_AutomationResource_CreateSurfacesTopLevelErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var gr gqlReq
+		defer r.Body.Close()
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gr)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(gr.Query, "createAutomation") {
+			// No error_details, only top-level errors: every message surfaces,
+			// not just the first.
+			_, _ = io.WriteString(w, `{"errors":[{"message":"Name can't be blank"},{"message":"Event is invalid"}],"data":{"createAutomation":{"automation":null}}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":{}}`)
+	}))
+	defer srv.Close()
+
+	config := `
+	provider "pipefy" {
+		endpoint = "` + srv.URL + `"
+		token    = "testtoken"
+	}
+
+	resource "pipefy_automation" "test" {
+		name           = "Invalid automation"
+		event_id       = "field_updated"
+		action_id      = "update_card_field"
+		event_repo_id  = "306729113"
+		action_repo_id = "306729113"
+	}
+	`
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`Name can't be blank; Event is invalid`),
+			},
+		},
+	})
+}
+
+func TestUnit_AutomationResource_UpdateSurfacesErrorDetails(t *testing.T) {
+	failUpdate := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var gr gqlReq
+		defer r.Body.Close()
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gr)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch q := gr.Query; {
+		case strings.Contains(q, "createAutomation"):
+			_, _ = io.WriteString(w, `{"data":{"createAutomation":{"automation":{"id":"auto_1","name":"Auto","action_id":"generate_with_ai","event_id":"field_updated","active":true}}}}`)
+		case strings.Contains(q, "updateAutomation"):
+			if failUpdate {
+				_, _ = io.WriteString(w, `{"errors":[{"message":"All fields must be filled properly."}],"data":{"updateAutomation":{"automation":null,"error_details":[{"object_name":"field_map","object_key":"420173432","messages":["can't be blank"]}]}}}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"data":{"updateAutomation":{"automation":{"id":"auto_1"}}}}`)
+		case strings.Contains(q, "deleteAutomation"):
+			_, _ = io.WriteString(w, `{"data":{"deleteAutomation":{"success":true}}}`)
+		case strings.Contains(q, "automation("):
+			_, _ = io.WriteString(w, `{"data":{"automation":{"id":"auto_1","name":"Auto","action_id":"generate_with_ai","event_id":"field_updated","active":true,"event_repo":{"id":"repo"},"action_repo_v2":{"id":"repo"}}}}`)
+		default:
+			_, _ = io.WriteString(w, `{"data":{}}`)
+		}
+	}))
+	defer srv.Close()
+
+	base := `
+	provider "pipefy" {
+		endpoint = "` + srv.URL + `"
+		token    = "testtoken"
+	}
+
+	resource "pipefy_automation" "test" {
+		name           = "NAME"
+		event_id       = "field_updated"
+		action_id      = "generate_with_ai"
+		event_repo_id  = "306729113"
+		action_repo_id = "306729113"
+		active         = true
+	}
+	`
+	config := strings.ReplaceAll(base, "NAME", "Auto")
+	configUpdate := strings.ReplaceAll(base, "NAME", "Renamed Auto")
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				PreConfig:   func() { failUpdate = true },
+				Config:      configUpdate,
+				ExpectError: regexp.MustCompile(`field_map.*can't be blank`),
+			},
+		},
+	})
 }

--- a/internal/provider/resource_automation_test.go
+++ b/internal/provider/resource_automation_test.go
@@ -263,6 +263,296 @@ func TestUnit_AutomationResource_CreateSurfacesTopLevelErrors(t *testing.T) {
 	})
 }
 
+func TestUnit_AutomationResource_CreateJoinsErrorDetailMessages(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var gr gqlReq
+		defer r.Body.Close()
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gr)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(gr.Query, "createAutomation") {
+			_, _ = io.WriteString(w, `{"errors":[{"message":"All fields must be filled properly."}],"data":{"createAutomation":{"automation":null,"error_details":[{"object_name":"field_map","object_key":"420173432","messages":["can't be blank","is invalid"]}]}}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":{}}`)
+	}))
+	defer srv.Close()
+
+	config := `
+	provider "pipefy" {
+		endpoint = "` + srv.URL + `"
+		token    = "testtoken"
+	}
+
+	resource "pipefy_automation" "test" {
+		name           = "Invalid automation"
+		event_id       = "field_updated"
+		action_id      = "update_card_field"
+		event_repo_id  = "306729113"
+		action_repo_id = "306729113"
+	}
+	`
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`field_map \(420173432\): can't be blank; is invalid`),
+			},
+		},
+	})
+}
+
+func TestUnit_AutomationResource_CreateFallsBackToTopLevelErrorWhenDetailsBlank(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var gr gqlReq
+		defer r.Body.Close()
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gr)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(gr.Query, "createAutomation") {
+			_, _ = io.WriteString(w, `{"errors":[{"message":"All fields must be filled properly."}],"data":{"createAutomation":{"automation":null,"error_details":[{"object_name":"","object_key":"","messages":[]}]}}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":{}}`)
+	}))
+	defer srv.Close()
+
+	config := `
+	provider "pipefy" {
+		endpoint = "` + srv.URL + `"
+		token    = "testtoken"
+	}
+
+	resource "pipefy_automation" "test" {
+		name           = "Invalid automation"
+		event_id       = "field_updated"
+		action_id      = "update_card_field"
+		event_repo_id  = "306729113"
+		action_repo_id = "306729113"
+	}
+	`
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`All fields must be filled properly`),
+			},
+		},
+	})
+}
+
+func TestUnit_AutomationResource_CreateReportsGenericErrorWhenNoAutomationOrDetails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var gr gqlReq
+		defer r.Body.Close()
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gr)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(gr.Query, "createAutomation") {
+			_, _ = io.WriteString(w, `{"data":{"createAutomation":{"automation":null}}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":{}}`)
+	}))
+	defer srv.Close()
+
+	config := `
+	provider "pipefy" {
+		endpoint = "` + srv.URL + `"
+		token    = "testtoken"
+	}
+
+	resource "pipefy_automation" "test" {
+		name           = "Invalid automation"
+		event_id       = "field_updated"
+		action_id      = "update_card_field"
+		event_repo_id  = "306729113"
+		action_repo_id = "306729113"
+	}
+	`
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`the API returned no automation and no error_details`),
+			},
+		},
+	})
+}
+
+func TestUnit_AutomationResource_CreatePersistsStateWhenAutomationReturnedWithErrorDetails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var gr gqlReq
+		defer r.Body.Close()
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gr)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch q := gr.Query; {
+		case strings.Contains(q, "createAutomation"):
+			_, _ = io.WriteString(w, `{"data":{"createAutomation":{"automation":{"id":"auto_1","name":"Auto","action_id":"generate_with_ai","event_id":"field_updated","active":true},"error_details":[{"object_name":"field_map","object_key":"420173432","messages":["can't be blank"]}]}}}`)
+		case strings.Contains(q, "automation("):
+			_, _ = io.WriteString(w, `{"data":{"automation":{"id":"auto_1","name":"Auto","action_id":"generate_with_ai","event_id":"field_updated","active":true,"event_repo":{"id":"repo"},"action_repo_v2":{"id":"repo"}}}}`)
+		case strings.Contains(q, "deleteAutomation"):
+			_, _ = io.WriteString(w, `{"data":{"deleteAutomation":{"success":true}}}`)
+		default:
+			_, _ = io.WriteString(w, `{"data":{}}`)
+		}
+	}))
+	defer srv.Close()
+
+	config := `
+	provider "pipefy" {
+		endpoint = "` + srv.URL + `"
+		token    = "testtoken"
+	}
+
+	resource "pipefy_automation" "test" {
+		name           = "Auto"
+		event_id       = "field_updated"
+		action_id      = "generate_with_ai"
+		event_repo_id  = "306729113"
+		action_repo_id = "306729113"
+		active         = true
+	}
+	`
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"pipefy_automation.test",
+						tfjsonpath.New("id"),
+						knownvalue.StringExact("auto_1"),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestUnit_AutomationResource_CreateRejectsInvalidActionParamsJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{}}`)
+	}))
+	defer srv.Close()
+
+	config := `
+	provider "pipefy" {
+		endpoint = "` + srv.URL + `"
+		token    = "testtoken"
+	}
+
+	resource "pipefy_automation" "test" {
+		name           = "Auto"
+		event_id       = "field_updated"
+		action_id      = "generate_with_ai"
+		event_repo_id  = "306729113"
+		action_repo_id = "306729113"
+		action_params  = "{not valid json"
+	}
+	`
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`invalid action_params JSON`),
+			},
+		},
+	})
+}
+
+func TestUnit_AutomationResource_UpdateSurfacesTopLevelErrors(t *testing.T) {
+	failUpdate := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var gr gqlReq
+		defer r.Body.Close()
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gr)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch q := gr.Query; {
+		case strings.Contains(q, "createAutomation"):
+			_, _ = io.WriteString(w, `{"data":{"createAutomation":{"automation":{"id":"auto_1","name":"Auto","action_id":"generate_with_ai","event_id":"field_updated","active":true}}}}`)
+		case strings.Contains(q, "updateAutomation"):
+			if failUpdate {
+				_, _ = io.WriteString(w, `{"errors":[{"message":"Name can't be blank"},{"message":"Event is invalid"}],"data":{"updateAutomation":{"automation":null}}}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"data":{"updateAutomation":{"automation":{"id":"auto_1"}}}}`)
+		case strings.Contains(q, "deleteAutomation"):
+			_, _ = io.WriteString(w, `{"data":{"deleteAutomation":{"success":true}}}`)
+		case strings.Contains(q, "automation("):
+			_, _ = io.WriteString(w, `{"data":{"automation":{"id":"auto_1","name":"Auto","action_id":"generate_with_ai","event_id":"field_updated","active":true,"event_repo":{"id":"repo"},"action_repo_v2":{"id":"repo"}}}}`)
+		default:
+			_, _ = io.WriteString(w, `{"data":{}}`)
+		}
+	}))
+	defer srv.Close()
+
+	base := `
+	provider "pipefy" {
+		endpoint = "` + srv.URL + `"
+		token    = "testtoken"
+	}
+
+	resource "pipefy_automation" "test" {
+		name           = "NAME"
+		event_id       = "field_updated"
+		action_id      = "generate_with_ai"
+		event_repo_id  = "306729113"
+		action_repo_id = "306729113"
+		active         = true
+	}
+	`
+	config := strings.ReplaceAll(base, "NAME", "Auto")
+	configUpdate := strings.ReplaceAll(base, "NAME", "Renamed Auto")
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				PreConfig:   func() { failUpdate = true },
+				Config:      configUpdate,
+				ExpectError: regexp.MustCompile(`Name can't be blank; Event is invalid`),
+			},
+		},
+	})
+}
+
 func TestUnit_AutomationResource_UpdateSurfacesErrorDetails(t *testing.T) {
 	failUpdate := false
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/provider/resources/resource_automation.go
+++ b/internal/provider/resources/resource_automation.go
@@ -63,6 +63,19 @@ func formatAutomationErrorDetails(details []automationErrorDetail) string {
 	return strings.Join(lines, "\n")
 }
 
+func automationError(automationPresent bool, details []automationErrorDetail, err error) string {
+	if automationPresent {
+		return ""
+	}
+	if detail := formatAutomationErrorDetails(details); detail != "" {
+		return detail
+	}
+	if err != nil {
+		return err.Error()
+	}
+	return "the API returned no automation and no error_details"
+}
+
 func (r *AutomationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_automation"
 }
@@ -162,16 +175,8 @@ func (r *AutomationResource) Create(ctx context.Context, req resource.CreateRequ
 		} `json:"createAutomation"`
 	}
 	err := r.api.DoGraphQL(ctx, mutation, vars, &out)
-	if len(out.CreateAutomation.ErrorDetails) > 0 {
-		resp.Diagnostics.AddError("create automation failed", formatAutomationErrorDetails(out.CreateAutomation.ErrorDetails))
-		return
-	}
-	if err != nil {
-		resp.Diagnostics.AddError("create automation failed", err.Error())
-		return
-	}
-	if out.CreateAutomation.Automation == nil {
-		resp.Diagnostics.AddError("create automation failed", "the API returned no automation and no error_details")
+	if detail := automationError(out.CreateAutomation.Automation != nil, out.CreateAutomation.ErrorDetails, err); detail != "" {
+		resp.Diagnostics.AddError("create automation failed", detail)
 		return
 	}
 	data.Id = types.StringValue(out.CreateAutomation.Automation.Id)
@@ -280,16 +285,8 @@ func (r *AutomationResource) Update(ctx context.Context, req resource.UpdateRequ
 		} `json:"updateAutomation"`
 	}
 	err := r.api.DoGraphQL(ctx, mutation, vars, &out)
-	if len(out.UpdateAutomation.ErrorDetails) > 0 {
-		resp.Diagnostics.AddError("update automation failed", formatAutomationErrorDetails(out.UpdateAutomation.ErrorDetails))
-		return
-	}
-	if err != nil {
-		resp.Diagnostics.AddError("update automation failed", err.Error())
-		return
-	}
-	if out.UpdateAutomation.Automation == nil {
-		resp.Diagnostics.AddError("update automation failed", "the API returned no automation and no error_details")
+	if detail := automationError(out.UpdateAutomation.Automation != nil, out.UpdateAutomation.ErrorDetails, err); detail != "" {
+		resp.Diagnostics.AddError("update automation failed", detail)
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/resources/resource_automation.go
+++ b/internal/provider/resources/resource_automation.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -35,6 +36,31 @@ type AutomationModel struct {
 	ActionParams types.String `tfsdk:"action_params"`
 	Condition    types.String `tfsdk:"condition"`
 	Active       types.Bool   `tfsdk:"active"`
+}
+
+type automationErrorDetail struct {
+	ObjectName string   `json:"object_name"`
+	ObjectKey  string   `json:"object_key"`
+	Messages   []string `json:"messages"`
+}
+
+func formatAutomationErrorDetails(details []automationErrorDetail) string {
+	lines := make([]string, len(details))
+	for i, d := range details {
+		label := d.ObjectName
+		if d.ObjectKey != "" {
+			label = strings.TrimSpace(label + " (" + d.ObjectKey + ")")
+		}
+		segments := make([]string, 0, 2)
+		if label != "" {
+			segments = append(segments, label)
+		}
+		if msg := strings.Join(d.Messages, "; "); msg != "" {
+			segments = append(segments, msg)
+		}
+		lines[i] = strings.Join(segments, ": ")
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (r *AutomationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -132,15 +158,20 @@ func (r *AutomationResource) Create(ctx context.Context, req resource.CreateRequ
 				EventId  string `json:"event_id"`
 				Active   bool   `json:"active"`
 			} `json:"automation"`
-			ErrorDetails any `json:"error_details"`
+			ErrorDetails []automationErrorDetail `json:"error_details"`
 		} `json:"createAutomation"`
 	}
-	if err := r.api.DoGraphQL(ctx, mutation, vars, &out); err != nil {
+	err := r.api.DoGraphQL(ctx, mutation, vars, &out)
+	if len(out.CreateAutomation.ErrorDetails) > 0 {
+		resp.Diagnostics.AddError("create automation failed", formatAutomationErrorDetails(out.CreateAutomation.ErrorDetails))
+		return
+	}
+	if err != nil {
 		resp.Diagnostics.AddError("create automation failed", err.Error())
 		return
 	}
 	if out.CreateAutomation.Automation == nil {
-		resp.Diagnostics.AddError("create automation failed", "no automation returned; check error_details in API")
+		resp.Diagnostics.AddError("create automation failed", "the API returned no automation and no error_details")
 		return
 	}
 	data.Id = types.StringValue(out.CreateAutomation.Automation.Id)
@@ -245,15 +276,20 @@ func (r *AutomationResource) Update(ctx context.Context, req resource.UpdateRequ
 			Automation *struct {
 				Id string `json:"id"`
 			} `json:"automation"`
-			ErrorDetails any `json:"error_details"`
+			ErrorDetails []automationErrorDetail `json:"error_details"`
 		} `json:"updateAutomation"`
 	}
-	if err := r.api.DoGraphQL(ctx, mutation, vars, &out); err != nil {
+	err := r.api.DoGraphQL(ctx, mutation, vars, &out)
+	if len(out.UpdateAutomation.ErrorDetails) > 0 {
+		resp.Diagnostics.AddError("update automation failed", formatAutomationErrorDetails(out.UpdateAutomation.ErrorDetails))
+		return
+	}
+	if err != nil {
 		resp.Diagnostics.AddError("update automation failed", err.Error())
 		return
 	}
 	if out.UpdateAutomation.Automation == nil {
-		resp.Diagnostics.AddError("update automation failed", "no automation returned; check error_details in API")
+		resp.Diagnostics.AddError("update automation failed", "the API returned no automation and no error_details")
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)


### PR DESCRIPTION
## What

`createAutomation` and `updateAutomation` return `error_details { object_name object_key messages }`. The automation resource already selected these fields but discarded them, so a rejected mutation surfaced only a generic error.

The API returns the field-level `error_details` inside `data`, alongside a generic top-level GraphQL error, in the same response. An automation whose `action_params.field_map` writes a blank value to a required field returns:

```json
{
  "data": { "createAutomation": { "automation": null,
    "error_details": [{ "object_name": "field_map", "object_key": "431176373", "messages": ["can't be blank"] }] } },
  "errors": [{ "message": "All fields must be filled properly." }]
}
```

The client discarded `data` whenever top-level errors were present, so the user saw `All fields must be filled properly.` and never the specific `field_map ... can't be blank`.

## Changes

- `client/api_client.go`: extract `execGraphQL` for the HTTP round-trip. `DoGraphQL` now unmarshals `data` into `out` even when top-level errors are present, and returns an error joining all top-level messages instead of only the first. `out` is populated even when an error is returned. Top-level errors take precedence over a data-decode mismatch.
- `resources/resource_automation.go`: parse `error_details` into a typed struct. `Create` and `Update` surface, in order, `error_details` (field-level) then the joined top-level error then a no-automation fallback, failing without writing state.
- Tests: client coverage for data and errors coexisting, decode-mismatch precedence, and `data:null`; automation coverage for `error_details` on create and update, and the top-level-error fallback.

## Compatibility

Other resources and data sources are unaffected. They return on a non-nil error before reading the decoded payload, so populating `out` on error is invisible to them. The only observable change for them is richer error text: all top-level messages instead of the first.

## Known limitation

If a single mutation fails on both a generic field and `action_params`, only `error_details` is surfaced and a distinct generic top-level message would be dropped. In practice the top-level message that accompanies `error_details` is the generic umbrella, so nothing actionable is lost.

## Verification

- `go test ./...` (60 tests), `go vet ./...`, and `gofmt` are clean locally. `golangci-lint` runs in CI.
- Verified against a live stack: before this change a rejected automation reported `All fields must be filled properly.`; after, it reports `field_map (...): can't be blank`. The payload shape was confirmed by GraphQL introspection of `CreateAutomationPayload` and `InternalError`.
- Coverage is via unit tests plus the manual live check, consistent with the resource's existing `TestUnit_*` pattern; no `TF_ACC` acceptance test was added.

Closes #42
