### PR TITLE
ci: set goreleaser release mode to replace

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,6 +52,10 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
+  # replace overwrites a release's existing assets on re-run instead of failing
+  # with "already_exists", so a release left partial by a transient upload error
+  # can be recovered by re-running the workflow.
+  mode: replace
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,9 +52,6 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
-  # replace overwrites a release's existing assets on re-run instead of failing
-  # with "already_exists", so a release left partial by a transient upload error
-  # can be recovered by re-running the workflow.
   mode: replace
   extra_files:
     - glob: 'terraform-registry-manifest.json'


### PR DESCRIPTION
## What

Set `release.mode: replace` in `.goreleaser.yml`.

## Why

The `v0.0.8-pre` release failed twice:

1. A transient GitHub upload error (HTTP/2 `REFUSED_STREAM`) dropped one asset (`windows_arm64.zip`) mid-upload. The release still published with 15 of 16 assets.
2. Re-running the workflow failed with `422 … already_exists` on every asset the first run had uploaded. goreleaser's default mode doesn't overwrite existing assets, so a partial release can't be recovered by re-running.

`mode: replace` overwrites a release's existing assets on re-run, making the release step idempotent: a transient upload failure can be fixed by re-running the workflow rather than manually deleting the release first.

## Notes

This affects future tags only. The `v0.0.8-pre` release was recovered separately by deleting the partial release (tag kept) and re-running the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
