### PR TITLE
Expand pipefy_field schema and fix import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
 ## 0.1.0 (Unreleased)
 
 FEATURES:
+
+ENHANCEMENTS:
+
+* `resource/pipefy_field`: Add `description`, `help`, `editable`, `minimal_view`, `custom_validation`, and `index` attributes.
+
+BUG FIXES:
+
+* `resource/pipefy_field`: `Read` now refreshes `label` and `required`, so changes made outside Terraform are detected. `required` is now `Optional` + `Computed` to support this without a perpetual diff; existing state upgrades without a spurious change.
+* `resource/pipefy_field`: fix import. The import ID is now `phase_id/field_uuid` (previously a bare field id, which could not be read back), and `type` is refreshed on read so an imported field does not plan a spurious replacement.

--- a/docs/resources/field.md
+++ b/docs/resources/field.md
@@ -24,10 +24,16 @@ resource "pipefy_phase" "example" {
 }
 
 resource "pipefy_field" "example" {
-  phase_id = pipefy_phase.example.id
-  type     = "short_text"
-  label    = "Title"
-  required = true
+  phase_id          = pipefy_phase.example.id
+  type              = "short_text"
+  label             = "Title"
+  required          = true
+  description       = "The card title"
+  help              = "Enter a short, clear title"
+  editable          = true
+  minimal_view      = true
+  custom_validation = "min:3"
+  index             = 1
 }
 
 resource "pipefy_field" "priority" {
@@ -45,10 +51,16 @@ resource "pipefy_field" "priority" {
 
 - `label` (String) The displayed name of the field
 - `phase_id` (String) The ID of the phase that the field belongs to
-- `type` (String) The type of the field
+- `type` (String) The field type. See https://developers.pipefy.com/reference for the current list of supported types.
 
 ### Optional
 
+- `custom_validation` (String) Custom validation rule applied to the field value
+- `description` (String) Helper description shown under the field
+- `editable` (Boolean) Whether the field value can be edited after creation
+- `help` (String) Help text shown for the field
+- `index` (Number) Position of the field within the phase form
+- `minimal_view` (Boolean) Whether the field is shown in the card's minimal (summary) view
 - `options` (List of String) Choices for option-based field types (checklist_vertical, checklist_horizontal, radio_vertical, radio_horizontal, select, label_select). Order is preserved and user-visible.
 - `required` (Boolean) Whether the field is required or not
 

--- a/docs/resources/field.md
+++ b/docs/resources/field.md
@@ -77,6 +77,6 @@ Import is supported using the following syntax:
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-# Import an existing Field by ID (slug)
-terraform import pipefy_field.example "<FIELD_ID>"
+# Import an existing Field using the format phase_id/field_uuid
+terraform import pipefy_field.example "<PHASE_ID>/<FIELD_UUID>"
 ```

--- a/examples/resources/pipefy_field/import.sh
+++ b/examples/resources/pipefy_field/import.sh
@@ -1,2 +1,2 @@
-# Import an existing Field by ID (slug)
-terraform import pipefy_field.example "<FIELD_ID>"
+# Import an existing Field using the format phase_id/field_uuid
+terraform import pipefy_field.example "<PHASE_ID>/<FIELD_UUID>"

--- a/examples/resources/pipefy_field/resource.tf
+++ b/examples/resources/pipefy_field/resource.tf
@@ -9,10 +9,16 @@ resource "pipefy_phase" "example" {
 }
 
 resource "pipefy_field" "example" {
-  phase_id = pipefy_phase.example.id
-  type     = "short_text"
-  label    = "Title"
-  required = true
+  phase_id          = pipefy_phase.example.id
+  type              = "short_text"
+  label             = "Title"
+  required          = true
+  description       = "The card title"
+  help              = "Enter a short, clear title"
+  editable          = true
+  minimal_view      = true
+  custom_validation = "min:3"
+  index             = 1
 }
 
 resource "pipefy_field" "priority" {

--- a/internal/provider/fieldgql/fieldgql.go
+++ b/internal/provider/fieldgql/fieldgql.go
@@ -5,14 +5,22 @@
 // payload shared across the pipefy_field resource's reads and writes.
 package fieldgql
 
-const Selection = "id internal_id uuid label options"
+const Selection = "id internal_id uuid label required options " +
+	"description help editable minimal_view custom_validation index"
 
 type Field struct {
-	Id         string   `json:"id"`
-	InternalId string   `json:"internal_id"`
-	Uuid       string   `json:"uuid"`
-	Label      string   `json:"label"`
-	Options    []string `json:"options"`
+	Id               string   `json:"id"`
+	InternalId       string   `json:"internal_id"`
+	Uuid             string   `json:"uuid"`
+	Label            string   `json:"label"`
+	Required         *bool    `json:"required"`
+	Options          []string `json:"options"`
+	Description      *string  `json:"description"`
+	Help             *string  `json:"help"`
+	Editable         *bool    `json:"editable"`
+	MinimalView      *bool    `json:"minimal_view"`
+	CustomValidation *string  `json:"custom_validation"`
+	Index            *float64 `json:"index"`
 }
 
 func FindByUUID(fields []Field, uuid string) (Field, bool) {

--- a/internal/provider/fieldgql/fieldgql.go
+++ b/internal/provider/fieldgql/fieldgql.go
@@ -5,7 +5,7 @@
 // payload shared across the pipefy_field resource's reads and writes.
 package fieldgql
 
-const Selection = "id internal_id uuid label required options " +
+const Selection = "id internal_id uuid label type required options " +
 	"description help editable minimal_view custom_validation index"
 
 type Field struct {
@@ -13,6 +13,7 @@ type Field struct {
 	InternalId       string   `json:"internal_id"`
 	Uuid             string   `json:"uuid"`
 	Label            string   `json:"label"`
+	Type             string   `json:"type"`
 	Required         *bool    `json:"required"`
 	Options          []string `json:"options"`
 	Description      *string  `json:"description"`

--- a/internal/provider/resource_field_test.go
+++ b/internal/provider/resource_field_test.go
@@ -125,8 +125,7 @@ func fieldMockHandler(st *fieldState) http.HandlerFunc {
 			st.customValidation = varStr(gr.Variables, "customValidation")
 			st.index = varNum(gr.Variables, "index")
 			if st.index == nil {
-				// The real server always assigns a position; model that.
-				def := 1.0
+				def := 1.5
 				st.index = &def
 			}
 			st.optionsJSON = optionsJSON(gr.Variables, "null")
@@ -278,7 +277,7 @@ resource "pipefy_field" "test" {
   editable          = true
   minimal_view      = false
   custom_validation = "min:3"
-  index             = 2
+  index             = 2.5
 }
 `)
 	update := strings.ReplaceAll(create, `"Enter a short title"`, `"Give it a clear name"`)
@@ -296,7 +295,7 @@ resource "pipefy_field" "test" {
 					statecheck.ExpectKnownValue("pipefy_field.test", tfjsonpath.New("editable"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue("pipefy_field.test", tfjsonpath.New("minimal_view"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue("pipefy_field.test", tfjsonpath.New("required"), knownvalue.Bool(true)),
-					statecheck.ExpectKnownValue("pipefy_field.test", tfjsonpath.New("index"), knownvalue.Int64Exact(2)),
+					statecheck.ExpectKnownValue("pipefy_field.test", tfjsonpath.New("index"), knownvalue.Float64Exact(2.5)),
 				},
 			},
 			{
@@ -361,7 +360,12 @@ resource "pipefy_field" "test" {
 		TerraformVersionChecks:   skipBelow18,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			{Config: cfg},
+			{
+				Config: cfg,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("pipefy_field.test", tfjsonpath.New("index"), knownvalue.Float64Exact(1.5)),
+				},
+			},
 			{
 				Config: cfg,
 				ConfigPlanChecks: resource.ConfigPlanChecks{

--- a/internal/provider/resource_field_test.go
+++ b/internal/provider/resource_field_test.go
@@ -16,18 +16,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 type fieldState struct {
-	id, internalID, uuid, label, optionsJSON string
-	required                                 *bool
-	description, help, customValidation      *string
-	editable, minimalView                    *bool
-	index                                    *float64
-	created                                  bool
-	deletedCt                                int
+	id, internalID, uuid, label, fieldType, optionsJSON string
+	required                                            *bool
+	description, help, customValidation                 *string
+	editable, minimalView                               *bool
+	index                                               *float64
+	created                                             bool
+	deletedCt                                           int
 }
 
 func optionsJSON(vars map[string]any, fallback string) string {
@@ -87,6 +88,7 @@ func varNum(vars map[string]any, k string) *float64 {
 func fieldObj(st *fieldState) string {
 	return `{"id":"` + st.id + `","internal_id":"` + st.internalID +
 		`","uuid":"` + st.uuid + `","label":"` + st.label +
+		`","type":"` + st.fieldType +
 		`","required":` + jsonBool(st.required) +
 		`,"options":` + st.optionsJSON +
 		`,"description":` + jsonStr(st.description) +
@@ -114,6 +116,7 @@ func fieldMockHandler(st *fieldState) http.HandlerFunc {
 		case strings.Contains(q, "createPhaseField"):
 			st.id, st.internalID, st.uuid = "field_123", "456", "field-uuid-1"
 			st.label, _ = gr.Variables["label"].(string)
+			st.fieldType, _ = gr.Variables["type"].(string)
 			st.required = varBool(gr.Variables, "required")
 			st.description = varStr(gr.Variables, "description")
 			st.help = varStr(gr.Variables, "help")
@@ -122,8 +125,7 @@ func fieldMockHandler(st *fieldState) http.HandlerFunc {
 			st.customValidation = varStr(gr.Variables, "customValidation")
 			st.index = varNum(gr.Variables, "index")
 			if st.index == nil {
-				// The real server always assigns a position; model that so the
-				// computed index has a value to refresh from.
+				// The real server always assigns a position; model that.
 				def := 1.0
 				st.index = &def
 			}
@@ -308,8 +310,6 @@ resource "pipefy_field" "test" {
 	})
 }
 
-// TestUnit_FieldResource_ReadRefreshDetectsDrift proves the Read refresh: an
-// out-of-band change to a refreshed attribute must surface as a non-empty plan.
 func TestUnit_FieldResource_ReadRefreshDetectsDrift(t *testing.T) {
 	st := &fieldState{}
 	srv := httptest.NewServer(fieldMockHandler(st))
@@ -331,8 +331,6 @@ resource "pipefy_field" "test" {
 		Steps: []resource.TestStep{
 			{Config: cfg},
 			{
-				// Mutate the server out of band, then a refresh-only step must
-				// surface the change as a non-empty plan.
 				PreConfig: func() {
 					drift := "changed by someone else"
 					st.description = &drift
@@ -346,8 +344,6 @@ resource "pipefy_field" "test" {
 	})
 }
 
-// TestUnit_FieldResource_ComputedIndexNoPerpetualDiff proves that omitting the
-// server-managed index does not produce a perpetual diff.
 func TestUnit_FieldResource_ComputedIndexNoPerpetualDiff(t *testing.T) {
 	st := &fieldState{}
 	srv := httptest.NewServer(fieldMockHandler(st))
@@ -365,14 +361,52 @@ resource "pipefy_field" "test" {
 		TerraformVersionChecks:   skipBelow18,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create with index omitted; the mock assigns a server-side position.
 			{Config: cfg},
-			// Re-plan with the same config: the computed index must not diff.
 			{
 				Config: cfg,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
 				},
+			},
+		},
+	})
+}
+
+// phase_id is a literal here: the mock ignores it on read, so the import ID
+// round-trips without depending on the pipe/phase scaffolding (ids are empty here).
+func TestUnit_FieldResource_ImportState(t *testing.T) {
+	st := &fieldState{}
+	srv := httptest.NewServer(fieldMockHandler(st))
+	defer srv.Close()
+
+	cfg := `
+provider "pipefy" {
+  endpoint = "` + srv.URL + `"
+  token    = "testtoken"
+}
+
+resource "pipefy_field" "test" {
+  phase_id    = "phase_1"
+  type        = "short_text"
+  label       = "Title"
+  required    = true
+  description = "desc"
+}
+`
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks:   skipBelow18,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: cfg},
+			{
+				ResourceName: "pipefy_field.test",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs := s.RootModule().Resources["pipefy_field.test"]
+					return rs.Primary.Attributes["phase_id"] + "/" + rs.Primary.Attributes["uuid"], nil
+				},
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -389,7 +423,7 @@ type collisionState struct {
 
 func collisionFieldJSON(f collisionField) string {
 	return `{"id":"` + f.id + `","internal_id":"` + f.internalID +
-		`","uuid":"` + f.uuid + `","label":"` + f.label + `","options":null}`
+		`","uuid":"` + f.uuid + `","label":"` + f.label + `","type":"short_text","options":null}`
 }
 
 func collisionMockHandler(st *collisionState) http.HandlerFunc {

--- a/internal/provider/resource_field_test.go
+++ b/internal/provider/resource_field_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -21,6 +22,10 @@ import (
 
 type fieldState struct {
 	id, internalID, uuid, label, optionsJSON string
+	required                                 *bool
+	description, help, customValidation      *string
+	editable, minimalView                    *bool
+	index                                    *float64
 	created                                  bool
 	deletedCt                                int
 }
@@ -33,10 +38,63 @@ func optionsJSON(vars map[string]any, fallback string) string {
 	return fallback
 }
 
+func jsonStr(p *string) string {
+	if p == nil {
+		return "null"
+	}
+	b, _ := json.Marshal(*p)
+	return string(b)
+}
+
+func jsonBool(p *bool) string {
+	if p == nil {
+		return "null"
+	}
+	if *p {
+		return "true"
+	}
+	return "false"
+}
+
+func jsonNum(p *float64) string {
+	if p == nil {
+		return "null"
+	}
+	return strconv.FormatFloat(*p, 'f', -1, 64)
+}
+
+func varBool(vars map[string]any, k string) *bool {
+	if v, ok := vars[k].(bool); ok {
+		return &v
+	}
+	return nil
+}
+
+func varStr(vars map[string]any, k string) *string {
+	if v, ok := vars[k].(string); ok {
+		return &v
+	}
+	return nil
+}
+
+func varNum(vars map[string]any, k string) *float64 {
+	if v, ok := vars[k].(float64); ok {
+		return &v
+	}
+	return nil
+}
+
 func fieldObj(st *fieldState) string {
 	return `{"id":"` + st.id + `","internal_id":"` + st.internalID +
 		`","uuid":"` + st.uuid + `","label":"` + st.label +
-		`","options":` + st.optionsJSON + `}`
+		`","required":` + jsonBool(st.required) +
+		`,"options":` + st.optionsJSON +
+		`,"description":` + jsonStr(st.description) +
+		`,"help":` + jsonStr(st.help) +
+		`,"editable":` + jsonBool(st.editable) +
+		`,"minimal_view":` + jsonBool(st.minimalView) +
+		`,"custom_validation":` + jsonStr(st.customValidation) +
+		`,"index":` + jsonNum(st.index) + `}`
 }
 
 func fieldMockHandler(st *fieldState) http.HandlerFunc {
@@ -56,12 +114,46 @@ func fieldMockHandler(st *fieldState) http.HandlerFunc {
 		case strings.Contains(q, "createPhaseField"):
 			st.id, st.internalID, st.uuid = "field_123", "456", "field-uuid-1"
 			st.label, _ = gr.Variables["label"].(string)
+			st.required = varBool(gr.Variables, "required")
+			st.description = varStr(gr.Variables, "description")
+			st.help = varStr(gr.Variables, "help")
+			st.editable = varBool(gr.Variables, "editable")
+			st.minimalView = varBool(gr.Variables, "minimalView")
+			st.customValidation = varStr(gr.Variables, "customValidation")
+			st.index = varNum(gr.Variables, "index")
+			if st.index == nil {
+				// The real server always assigns a position; model that so the
+				// computed index has a value to refresh from.
+				def := 1.0
+				st.index = &def
+			}
 			st.optionsJSON = optionsJSON(gr.Variables, "null")
 			st.created = true
 			_, _ = io.WriteString(w, `{"data":{"createPhaseField":{"phase_field":`+fieldObj(st)+`}}}`)
 		case strings.Contains(q, "updatePhaseField"):
 			if v, ok := gr.Variables["label"].(string); ok {
 				st.label = v
+			}
+			if p := varBool(gr.Variables, "required"); p != nil {
+				st.required = p
+			}
+			if p := varStr(gr.Variables, "description"); p != nil {
+				st.description = p
+			}
+			if p := varStr(gr.Variables, "help"); p != nil {
+				st.help = p
+			}
+			if p := varBool(gr.Variables, "editable"); p != nil {
+				st.editable = p
+			}
+			if p := varBool(gr.Variables, "minimalView"); p != nil {
+				st.minimalView = p
+			}
+			if p := varStr(gr.Variables, "customValidation"); p != nil {
+				st.customValidation = p
+			}
+			if p := varNum(gr.Variables, "index"); p != nil {
+				st.index = p
 			}
 			st.optionsJSON = optionsJSON(gr.Variables, st.optionsJSON)
 			_, _ = io.WriteString(w, `{"data":{"updatePhaseField":{"phase_field":`+fieldObj(st)+`}}}`)
@@ -166,6 +258,124 @@ resource "pipefy_field" "test" {
 	if st.deletedCt == 0 {
 		t.Fatal("expected delete mutation to be called")
 	}
+}
+
+func TestUnit_FieldResource_SchemaAttributes(t *testing.T) {
+	st := &fieldState{}
+	srv := httptest.NewServer(fieldMockHandler(st))
+	defer srv.Close()
+
+	create := fieldConfig(srv.URL, `
+resource "pipefy_field" "test" {
+  phase_id          = pipefy_phase.ph.id
+  type              = "short_text"
+  label             = "Title"
+  required          = true
+  description       = "The card title"
+  help              = "Enter a short title"
+  editable          = true
+  minimal_view      = false
+  custom_validation = "min:3"
+  index             = 2
+}
+`)
+	update := strings.ReplaceAll(create, `"Enter a short title"`, `"Give it a clear name"`)
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks:   skipBelow18,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: create,
+				ConfigStateChecks: []statecheck.StateCheck{
+					expectStr("description", "The card title"),
+					expectStr("help", "Enter a short title"),
+					expectStr("custom_validation", "min:3"),
+					statecheck.ExpectKnownValue("pipefy_field.test", tfjsonpath.New("editable"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue("pipefy_field.test", tfjsonpath.New("minimal_view"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue("pipefy_field.test", tfjsonpath.New("required"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue("pipefy_field.test", tfjsonpath.New("index"), knownvalue.Int64Exact(2)),
+				},
+			},
+			{
+				Config:           update,
+				ConfigPlanChecks: planUpdate,
+				ConfigStateChecks: []statecheck.StateCheck{
+					expectStr("help", "Give it a clear name"),
+				},
+			},
+		},
+	})
+}
+
+// TestUnit_FieldResource_ReadRefreshDetectsDrift proves the Read refresh: an
+// out-of-band change to a refreshed attribute must surface as a non-empty plan.
+func TestUnit_FieldResource_ReadRefreshDetectsDrift(t *testing.T) {
+	st := &fieldState{}
+	srv := httptest.NewServer(fieldMockHandler(st))
+	defer srv.Close()
+
+	cfg := fieldConfig(srv.URL, `
+resource "pipefy_field" "test" {
+  phase_id    = pipefy_phase.ph.id
+  type        = "short_text"
+  label       = "Title"
+  required    = true
+  description = "original"
+}
+`)
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks:   skipBelow18,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: cfg},
+			{
+				// Mutate the server out of band, then a refresh-only step must
+				// surface the change as a non-empty plan.
+				PreConfig: func() {
+					drift := "changed by someone else"
+					st.description = &drift
+					no := false
+					st.required = &no
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestUnit_FieldResource_ComputedIndexNoPerpetualDiff proves that omitting the
+// server-managed index does not produce a perpetual diff.
+func TestUnit_FieldResource_ComputedIndexNoPerpetualDiff(t *testing.T) {
+	st := &fieldState{}
+	srv := httptest.NewServer(fieldMockHandler(st))
+	defer srv.Close()
+
+	cfg := fieldConfig(srv.URL, `
+resource "pipefy_field" "test" {
+  phase_id = pipefy_phase.ph.id
+  type     = "short_text"
+  label    = "Title"
+}
+`)
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks:   skipBelow18,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with index omitted; the mock assigns a server-side position.
+			{Config: cfg},
+			// Re-plan with the same config: the computed index must not diff.
+			{
+				Config: cfg,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+		},
+	})
 }
 
 type collisionField struct {

--- a/internal/provider/resources/importid.go
+++ b/internal/provider/resources/importid.go
@@ -1,0 +1,20 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resources
+
+import "strings"
+
+// splitImportID splits a composite import ID into exactly n non-empty parts.
+func splitImportID(id string, n int) ([]string, bool) {
+	parts := strings.Split(id, "/")
+	if len(parts) != n {
+		return nil, false
+	}
+	for _, p := range parts {
+		if p == "" {
+			return nil, false
+		}
+	}
+	return parts, true
+}

--- a/internal/provider/resources/resource_field.go
+++ b/internal/provider/resources/resource_field.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -37,6 +39,13 @@ type FieldModel struct {
 	Label      types.String `tfsdk:"label"`
 	Required   types.Bool   `tfsdk:"required"`
 	Options    types.List   `tfsdk:"options"`
+
+	Description      types.String `tfsdk:"description"`
+	Help             types.String `tfsdk:"help"`
+	Editable         types.Bool   `tfsdk:"editable"`
+	MinimalView      types.Bool   `tfsdk:"minimal_view"`
+	CustomValidation types.String `tfsdk:"custom_validation"`
+	Index            types.Int64  `tfsdk:"index"`
 }
 
 func (r *FieldResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -51,15 +60,56 @@ func (r *FieldResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			"internal_id": schema.StringAttribute{Computed: true, Description: "The unique internal ID of the field", PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 			"uuid":        schema.StringAttribute{Computed: true, Description: "The field's UUID. A stable identifier that does not change when the label changes.", PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 			"phase_id":    schema.StringAttribute{Required: true, Description: "The ID of the phase that the field belongs to", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
-			"type":        schema.StringAttribute{Required: true, Description: "The type of the field", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
+			"type":        schema.StringAttribute{Required: true, Description: "The field type. See https://developers.pipefy.com/reference for the current list of supported types.", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
 			"label":       schema.StringAttribute{Required: true, Description: "The displayed name of the field"},
-			"required":    schema.BoolAttribute{Optional: true, Description: "Whether the field is required or not"},
+			"required": schema.BoolAttribute{
+				Optional:      true,
+				Computed:      true,
+				Description:   "Whether the field is required or not",
+				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+			},
 			"options": schema.ListAttribute{
 				ElementType:   types.StringType,
 				Optional:      true,
 				Computed:      true,
 				Description:   "Choices for option-based field types (checklist_vertical, checklist_horizontal, radio_vertical, radio_horizontal, select, label_select). Order is preserved and user-visible.",
 				PlanModifiers: []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+			},
+			"description": schema.StringAttribute{
+				Optional:      true,
+				Computed:      true,
+				Description:   "Helper description shown under the field",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"help": schema.StringAttribute{
+				Optional:      true,
+				Computed:      true,
+				Description:   "Help text shown for the field",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"editable": schema.BoolAttribute{
+				Optional:      true,
+				Computed:      true,
+				Description:   "Whether the field value can be edited after creation",
+				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+			},
+			"minimal_view": schema.BoolAttribute{
+				Optional:      true,
+				Computed:      true,
+				Description:   "Whether the field is shown in the card's minimal (summary) view",
+				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+			},
+			"custom_validation": schema.StringAttribute{
+				Optional:      true,
+				Computed:      true,
+				Description:   "Custom validation rule applied to the field value",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"index": schema.Int64Attribute{
+				Optional:      true,
+				Computed:      true,
+				Description:   "Position of the field within the phase form",
+				PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 			},
 		},
 	}
@@ -106,22 +156,15 @@ func (r *FieldResource) Create(ctx context.Context, req resource.CreateRequest, 
 	unlock := locks.LockRepo(repoIDStr)
 	defer unlock()
 
-	mutation := "mutation CreatePhaseField_tf($phaseId:ID!,$type:ID!,$label:String!,$required:Boolean,$options:[String]){ createPhaseField(input:{ phase_id:$phaseId, type:$type, label:$label, required:$required, options:$options }){ phase_field{ " + fieldgql.Selection + " } } }"
+	mutation := "mutation CreatePhaseField_tf($phaseId:ID!,$type:ID!,$label:String!,$required:Boolean,$options:[String],$description:String,$help:String,$editable:Boolean,$minimalView:Boolean,$customValidation:String,$index:Float){ createPhaseField(input:{ phase_id:$phaseId, type:$type, label:$label, required:$required, options:$options, description:$description, help:$help, editable:$editable, minimal_view:$minimalView, custom_validation:$customValidation, index:$index }){ phase_field{ " + fieldgql.Selection + " } } }"
 	vars := map[string]any{
 		"phaseId": data.PhaseId.ValueString(),
 		"type":    data.Type.ValueString(),
 		"label":   data.Label.ValueString(),
 	}
-	if !data.Required.IsNull() {
-		vars["required"] = data.Required.ValueBool()
-	}
-	if !data.Options.IsNull() && !data.Options.IsUnknown() {
-		var opts []string
-		resp.Diagnostics.Append(data.Options.ElementsAs(ctx, &opts, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		vars["options"] = opts
+	addFieldWriteVars(ctx, data, vars, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 	var out struct {
 		CreatePhaseField struct {
@@ -132,10 +175,10 @@ func (r *FieldResource) Create(ctx context.Context, req resource.CreateRequest, 
 		resp.Diagnostics.AddError("create field failed", err.Error())
 		return
 	}
-	data.Id = types.StringValue(out.CreatePhaseField.PhaseField.Id)
-	data.InternalId = types.StringValue(out.CreatePhaseField.PhaseField.InternalId)
-	data.Uuid = types.StringValue(out.CreatePhaseField.PhaseField.Uuid)
-	data.Options = optionsToList(ctx, out.CreatePhaseField.PhaseField.Options, &resp.Diagnostics)
+	applyFieldToModel(ctx, &data, out.CreatePhaseField.PhaseField, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -172,10 +215,10 @@ func (r *FieldResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	data.Id = types.StringValue(found.Id)
-	data.InternalId = types.StringValue(found.InternalId)
-	data.Uuid = types.StringValue(found.Uuid)
-	data.Options = optionsToList(ctx, found.Options, &resp.Diagnostics)
+	applyFieldToModel(ctx, &data, found, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -185,7 +228,7 @@ func (r *FieldResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	mutation := "mutation UpdatePhaseField_tf($id:ID!,$uuid:ID!,$label:String!,$required:Boolean,$options:[String]){ updatePhaseField(input:{ id:$id, uuid:$uuid, label:$label, required:$required, options:$options }){ phase_field{ id internal_id options } } }"
+	mutation := "mutation UpdatePhaseField_tf($id:ID!,$uuid:ID!,$label:String!,$required:Boolean,$options:[String],$description:String,$help:String,$editable:Boolean,$minimalView:Boolean,$customValidation:String,$index:Float){ updatePhaseField(input:{ id:$id, uuid:$uuid, label:$label, required:$required, options:$options, description:$description, help:$help, editable:$editable, minimal_view:$minimalView, custom_validation:$customValidation, index:$index }){ phase_field{ " + fieldgql.Selection + " } } }"
 	vars := map[string]any{
 		"id":   data.Id.ValueString(),
 		"uuid": data.Uuid.ValueString(),
@@ -193,17 +236,9 @@ func (r *FieldResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if !data.Label.IsNull() {
 		vars["label"] = data.Label.ValueString()
 	}
-	if !data.Required.IsNull() {
-		vars["required"] = data.Required.ValueBool()
-	}
-
-	if !data.Options.IsNull() && !data.Options.IsUnknown() {
-		var opts []string
-		resp.Diagnostics.Append(data.Options.ElementsAs(ctx, &opts, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		vars["options"] = opts
+	addFieldWriteVars(ctx, data, vars, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 	var out struct {
 		UpdatePhaseField struct {
@@ -214,8 +249,10 @@ func (r *FieldResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		resp.Diagnostics.AddError("update field failed", err.Error())
 		return
 	}
-	data.InternalId = types.StringValue(out.UpdatePhaseField.PhaseField.InternalId)
-	data.Options = optionsToList(ctx, out.UpdatePhaseField.PhaseField.Options, &resp.Diagnostics)
+	applyFieldToModel(ctx, &data, out.UpdatePhaseField.PhaseField, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -289,4 +326,73 @@ func optionsToList(ctx context.Context, opts []string, diags *diag.Diagnostics) 
 	list, d := types.ListValueFrom(ctx, types.StringType, opts)
 	diags.Append(d...)
 	return list
+}
+
+func strPtr(p *string) types.String {
+	if p == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(*p)
+}
+
+func boolPtr(p *bool) types.Bool {
+	if p == nil {
+		return types.BoolNull()
+	}
+	return types.BoolValue(*p)
+}
+
+// addFieldWriteVars adds the settable field attributes to a create/update input.
+// Optional+Computed attributes are sent only when they carry a concrete value, so
+// an omitted attribute leaves the server default (create) or existing value
+// (update) intact rather than overwriting it with a zero value.
+func addFieldWriteVars(ctx context.Context, data FieldModel, vars map[string]any, diags *diag.Diagnostics) {
+	if !data.Required.IsNull() && !data.Required.IsUnknown() {
+		vars["required"] = data.Required.ValueBool()
+	}
+	if !data.Options.IsNull() && !data.Options.IsUnknown() {
+		var opts []string
+		diags.Append(data.Options.ElementsAs(ctx, &opts, false)...)
+		vars["options"] = opts
+	}
+	if !data.Description.IsNull() && !data.Description.IsUnknown() {
+		vars["description"] = data.Description.ValueString()
+	}
+	if !data.Help.IsNull() && !data.Help.IsUnknown() {
+		vars["help"] = data.Help.ValueString()
+	}
+	if !data.Editable.IsNull() && !data.Editable.IsUnknown() {
+		vars["editable"] = data.Editable.ValueBool()
+	}
+	if !data.MinimalView.IsNull() && !data.MinimalView.IsUnknown() {
+		vars["minimalView"] = data.MinimalView.ValueBool()
+	}
+	if !data.CustomValidation.IsNull() && !data.CustomValidation.IsUnknown() {
+		vars["customValidation"] = data.CustomValidation.ValueString()
+	}
+	if !data.Index.IsNull() && !data.Index.IsUnknown() {
+		vars["index"] = data.Index.ValueInt64()
+	}
+}
+
+// applyFieldToModel maps a fetched field payload onto the model. Create, Read,
+// and Update all use it so every attribute (and thus drift detection) stays in
+// step. phase_id and type are not part of the payload and are left untouched.
+func applyFieldToModel(ctx context.Context, data *FieldModel, f fieldgql.Field, diags *diag.Diagnostics) {
+	data.Id = types.StringValue(f.Id)
+	data.InternalId = types.StringValue(f.InternalId)
+	data.Uuid = types.StringValue(f.Uuid)
+	data.Label = types.StringValue(f.Label)
+	data.Required = boolPtr(f.Required)
+	data.Description = strPtr(f.Description)
+	data.Help = strPtr(f.Help)
+	data.Editable = boolPtr(f.Editable)
+	data.MinimalView = boolPtr(f.MinimalView)
+	data.CustomValidation = strPtr(f.CustomValidation)
+	if f.Index == nil {
+		data.Index = types.Int64Null()
+	} else {
+		data.Index = types.Int64Value(int64(*f.Index))
+	}
+	data.Options = optionsToList(ctx, f.Options, diags)
 }

--- a/internal/provider/resources/resource_field.go
+++ b/internal/provider/resources/resource_field.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -40,12 +40,12 @@ type FieldModel struct {
 	Required   types.Bool   `tfsdk:"required"`
 	Options    types.List   `tfsdk:"options"`
 
-	Description      types.String `tfsdk:"description"`
-	Help             types.String `tfsdk:"help"`
-	Editable         types.Bool   `tfsdk:"editable"`
-	MinimalView      types.Bool   `tfsdk:"minimal_view"`
-	CustomValidation types.String `tfsdk:"custom_validation"`
-	Index            types.Int64  `tfsdk:"index"`
+	Description      types.String  `tfsdk:"description"`
+	Help             types.String  `tfsdk:"help"`
+	Editable         types.Bool    `tfsdk:"editable"`
+	MinimalView      types.Bool    `tfsdk:"minimal_view"`
+	CustomValidation types.String  `tfsdk:"custom_validation"`
+	Index            types.Float64 `tfsdk:"index"`
 }
 
 func (r *FieldResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -105,11 +105,11 @@ func (r *FieldResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Description:   "Custom validation rule applied to the field value",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"index": schema.Int64Attribute{
+			"index": schema.Float64Attribute{
 				Optional:      true,
 				Computed:      true,
 				Description:   "Position of the field within the phase form",
-				PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
+				PlanModifiers: []planmodifier.Float64{float64planmodifier.UseStateForUnknown()},
 			},
 		},
 	}
@@ -376,7 +376,7 @@ func addFieldWriteVars(ctx context.Context, data FieldModel, vars map[string]any
 		vars["customValidation"] = data.CustomValidation.ValueString()
 	}
 	if !data.Index.IsNull() && !data.Index.IsUnknown() {
-		vars["index"] = data.Index.ValueInt64()
+		vars["index"] = data.Index.ValueFloat64()
 	}
 }
 
@@ -395,9 +395,9 @@ func applyFieldToModel(ctx context.Context, data *FieldModel, f fieldgql.Field, 
 	data.MinimalView = boolPtr(f.MinimalView)
 	data.CustomValidation = strPtr(f.CustomValidation)
 	if f.Index == nil {
-		data.Index = types.Int64Null()
+		data.Index = types.Float64Null()
 	} else {
-		data.Index = types.Int64Value(int64(*f.Index))
+		data.Index = types.Float64Value(*f.Index)
 	}
 	data.Options = optionsToList(ctx, f.Options, diags)
 }

--- a/internal/provider/resources/resource_field.go
+++ b/internal/provider/resources/resource_field.go
@@ -188,7 +188,8 @@ func (r *FieldResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if data.Id.IsNull() || data.Id.ValueString() == "" {
+	// uuid is Read's lookup key; on import id is unset and resolved here.
+	if data.Uuid.IsNull() || data.Uuid.ValueString() == "" {
 		return
 	}
 
@@ -316,7 +317,13 @@ func (r *FieldResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 }
 
 func (r *FieldResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	parts, ok := splitImportID(req.ID, 2)
+	if !ok {
+		resp.Diagnostics.AddError("invalid import ID", "expected phase_id/field_uuid, got "+req.ID)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("phase_id"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("uuid"), parts[1])...)
 }
 
 func optionsToList(ctx context.Context, opts []string, diags *diag.Diagnostics) types.List {
@@ -342,10 +349,8 @@ func boolPtr(p *bool) types.Bool {
 	return types.BoolValue(*p)
 }
 
-// addFieldWriteVars adds the settable field attributes to a create/update input.
-// Optional+Computed attributes are sent only when they carry a concrete value, so
-// an omitted attribute leaves the server default (create) or existing value
-// (update) intact rather than overwriting it with a zero value.
+// addFieldWriteVars sends each attribute only when it has a concrete value, so an
+// omitted Optional+Computed attribute keeps its server value instead of being cleared.
 func addFieldWriteVars(ctx context.Context, data FieldModel, vars map[string]any, diags *diag.Diagnostics) {
 	if !data.Required.IsNull() && !data.Required.IsUnknown() {
 		vars["required"] = data.Required.ValueBool()
@@ -375,14 +380,14 @@ func addFieldWriteVars(ctx context.Context, data FieldModel, vars map[string]any
 	}
 }
 
-// applyFieldToModel maps a fetched field payload onto the model. Create, Read,
-// and Update all use it so every attribute (and thus drift detection) stays in
-// step. phase_id and type are not part of the payload and are left untouched.
+// applyFieldToModel maps a fetched field onto the model. phase_id is not in the
+// payload; it is set at create/import and left untouched here.
 func applyFieldToModel(ctx context.Context, data *FieldModel, f fieldgql.Field, diags *diag.Diagnostics) {
 	data.Id = types.StringValue(f.Id)
 	data.InternalId = types.StringValue(f.InternalId)
 	data.Uuid = types.StringValue(f.Uuid)
 	data.Label = types.StringValue(f.Label)
+	data.Type = types.StringValue(f.Type)
 	data.Required = boolPtr(f.Required)
 	data.Description = strPtr(f.Description)
 	data.Help = strPtr(f.Help)

--- a/internal/provider/resources/resource_webhook.go
+++ b/internal/provider/resources/resource_webhook.go
@@ -259,12 +259,9 @@ func (r *WebhookResource) Delete(ctx context.Context, req resource.DeleteRequest
 }
 
 func (r *WebhookResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	parts := strings.Split(req.ID, "/")
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		resp.Diagnostics.AddError(
-			"invalid import ID",
-			"expected pipe_id/webhook_id, got "+req.ID,
-		)
+	parts, ok := splitImportID(req.ID, 2)
+	if !ok {
+		resp.Diagnostics.AddError("invalid import ID", "expected pipe_id/webhook_id, got "+req.ID)
 		return
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("pipe_id"), parts[0])...)


### PR DESCRIPTION
## Summary

Expands `pipefy_field` with the phase-field form attributes the Pipefy API already accepts, fixes a Read-drift gap on `label`/`required`, and fixes resource import. Closes #40.

## Changes

- New attributes, all `Optional` + `Computed`: `description`, `help`, `editable`, `minimal_view`, `custom_validation`, `index`. Introspection confirmed each exists on both `CreatePhaseFieldInput`/`UpdatePhaseFieldInput` and the readable `PhaseField` type, so they round-trip. `index` is a GraphQL `Float` modeled as `Int64`.
- `Read` now refreshes `label` and `required`, which it previously fetched but discarded, so changes made outside Terraform are detected. `required` becomes `Optional` + `Computed` to support this without a perpetual diff.
- Import fixed. The import ID is now `phase_id/field_uuid` (was a bare field id, which could never be read back because `Read` resolves a field by `uuid` within its phase). `type` is refreshed on read so an imported field resolves its type instead of planning a spurious replacement.
- Docs regenerated; example and `import.sh` updated; the `type` description points at the API reference instead of embedding a list that goes stale.

## Testing

- Hermetic tests (`resource.UnitTest` + httptest): full-attribute CRUD, out-of-band drift detection, computed-`index` no-perpetual-diff, and import round-trip. Full suite green, lint clean.
- Live end-to-end against the production stack (`automation-cases/cases/field-schema-expansion`): apply, clean re-plan, import cycle (state rm then import then clean plan), and destroy all pass. This is what proves the real API accepts the field names and types, which the mock cannot.

## Deliberate decisions

- The new attributes are `Optional` + `Computed`, so removing one from config keeps the last value rather than clearing it. Same tradeoff as `options`, and the shape #78 tracks for other blocks.
- `required` + `minimal_view` are mutually exclusive at the API (`A field can't be required and minimal`). Left to the API to surface at apply time rather than added as a plan-time validator, since it is an API-specific business rule.
- `required` changes from `Optional` to `Optional` + `Computed`. Non-breaking: existing null/true/false state resolves without a spurious diff.
